### PR TITLE
Freeze flake8 version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py34, py35, py36, py37, flake8
 
 [testenv:flake8]
 basepython = python
-deps = flake8
+deps = flake8==3.6.0
 commands = flake8 hcloud tests
 
 [testenv]


### PR DESCRIPTION
pyflakes version that is in flake8 >= 3.7.0
throws undefined name error on variable annotation.
flake8 converts it to F821. Before we find the way
how to deal with this issue, let us freeze flake8.