### PR TITLE
Rename hcloudAPIException to APIException

### DIFF
--- a/hcloud/__init__.py
+++ b/hcloud/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from .hcloud import HcloudClient, HcloudAPIException  # noqa
+from .hcloud import HcloudClient, APIException  # noqa

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -155,7 +155,7 @@ class FloatingIPsClient(ClientEntityBase):
     def delete(self, floating_ip):
         # type: (FloatingIP) -> bool
         self._client.request(url="/floating_ips/{floating_ip_id}".format(floating_ip_id=floating_ip.id), method="DELETE")
-        # Return allays true, because the API does not return an action for it. When an error occurs a HcloudAPIException will be raised
+        # Return allays true, because the API does not return an action for it. When an error occurs a APIException will be raised
         return True
 
     def change_protection(self, floating_ip, delete=None):

--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -18,7 +18,7 @@ from hcloud.datacenters.client import DatacentersClient
 from .version import VERSION, USER_AGENT_PREFIX
 
 
-class HcloudAPIException(Exception):
+class APIException(Exception):
     def __init__(self, code, message, details):
         self.code = code
         self.message = message
@@ -69,7 +69,7 @@ class HcloudClient(object):
         return headers
 
     def _raise_exception_from_response(self, response):
-        raise HcloudAPIException(
+        raise APIException(
             code=response.status_code,
             message=response.reason,
             details={
@@ -78,7 +78,7 @@ class HcloudClient(object):
         )
 
     def _raise_exception_from_json_content(self, json_content):
-        raise HcloudAPIException(
+        raise APIException(
             code=json_content['error']['code'],
             message=json_content['error']['message'],
             details=json_content['error']['details']

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -130,7 +130,7 @@ class ImagesClient(ClientEntityBase):
     def delete(self, image):
         # type: (Image) -> bool
         self._client.request(url="/images/{image_id}".format(image_id=image.id), method="DELETE")
-        # Return allays true, because the API does not return an action for it. When an error occurs a HcloudAPIException will be raised
+        # Return allays true, because the API does not return an action for it. When an error occurs a APIException will be raised
         return True
 
     def change_protection(self, image, delete=None):

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -77,5 +77,5 @@ class SSHKeysClient(ClientEntityBase):
     def delete(self, ssh_key):
         # type: (SSHKey) -> bool
         self._client.request(url="/ssh_keys/{ssh_key_id}".format(ssh_key_id=ssh_key.id), method="DELETE")
-        # Return allays true, because the API does not return an action for it. When an error occurs a HcloudAPIException will be raised
+        # Return allays true, because the API does not return an action for it. When an error occurs a APIException will be raised
         return True

--- a/tests/unit/test_hcloud.py
+++ b/tests/unit/test_hcloud.py
@@ -3,7 +3,7 @@
 import json
 import requests
 import pytest
-from hcloud import HcloudClient, HcloudAPIException
+from hcloud import HcloudClient, APIException
 
 
 class TestHetznerClient(object):
@@ -87,7 +87,7 @@ class TestHetznerClient(object):
 
     def test_request_fails(self, mocked_requests, client, fail_response):
         mocked_requests.request.return_value = fail_response
-        with pytest.raises(HcloudAPIException) as exception_info:
+        with pytest.raises(APIException) as exception_info:
             client.request("POST", "http://url.com", params={"argument": "value"}, timeout=2)
         error = exception_info.value
         assert error.code == "invalid_input"
@@ -99,7 +99,7 @@ class TestHetznerClient(object):
         fail_response.reason = "Internal Server Error"
         fail_response._content = "Internal Server Error"
         mocked_requests.request.return_value = fail_response
-        with pytest.raises(HcloudAPIException) as exception_info:
+        with pytest.raises(APIException) as exception_info:
             client.request("POST", "http://url.com", params={"argument": "value"}, timeout=2)
         error = exception_info.value
         assert error.code == 500
@@ -111,7 +111,7 @@ class TestHetznerClient(object):
         response.reason = "OK"
         response._content = content
         mocked_requests.request.return_value = response
-        with pytest.raises(HcloudAPIException) as exception_info:
+        with pytest.raises(APIException) as exception_info:
             client.request("POST", "http://url.com", params={"argument": "value"}, timeout=2)
         error = exception_info.value
         assert error.code == 200
@@ -131,7 +131,7 @@ class TestHetznerClient(object):
         fail_response.reason = "Internal Server Error"
         fail_response._content = ""
         mocked_requests.request.return_value = fail_response
-        with pytest.raises(HcloudAPIException) as exception_info:
+        with pytest.raises(APIException) as exception_info:
             client.request("POST", "http://url.com", params={"argument": "value"}, timeout=2)
         error = exception_info.value
         assert error.code == 500
@@ -141,7 +141,7 @@ class TestHetznerClient(object):
     def test_request_limit(self, mocked_requests, client, rate_limit_response):
         client.retry_wait_time = 0
         mocked_requests.request.return_value = rate_limit_response
-        with pytest.raises(HcloudAPIException) as exception_info:
+        with pytest.raises(APIException) as exception_info:
             client.request("POST", "http://url.com", params={"argument": "value"}, timeout=2)
         error = exception_info.value
         assert mocked_requests.request.call_count == 5


### PR DESCRIPTION
Because it looks a little bit funny to have a
`hcloud.hcloud.HcloudAPIException` raised
