### PR TITLE
Add pypi badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,8 @@ Hetzner Cloud Python
     :target: https://travis-ci.com/hetznercloud/hcloud-python
 .. image:: https://readthedocs.org/projects/hcloud-python/badge/?version=latest
     :target: https://hcloud-python.readthedocs.io
-
+.. image:: https://img.shields.io/pypi/pyversions/hcloud.svg
+    :target: https://pypi.org/project/hcloud/
 
     
 **IMPORTANT: This project is still in development and not ready production yet!**


### PR DESCRIPTION
This only works when we have at least one release. At the moment we have no release.