### PR TITLE
Add get_by_fingerprint to SSHKeyClient

### DIFF
--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -103,6 +103,18 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super(SSHKeysClient, self).get_by_name(name)
 
+    def get_by_fingerprint(self, fingerprint):
+        # type: (str) -> BoundSSHKey
+        """Get ssh key by fingerprint
+
+        :param fingerprint: str
+                Used to get ssh key by fingerprint.
+        :return: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>`
+        """
+        response = self.get_list(fingerprint=fingerprint)
+        sshkeys = response.ssh_keys
+        return sshkeys[0] if sshkeys else None
+
     def create(self, name, public_key, labels=None):
         # type: (str, str, Optional[Dict[str, str]]) -> BoundSSHKey
         """Creates a new SSH key with the given name and public_key.

--- a/tests/unit/ssh_keys/test_client.py
+++ b/tests/unit/ssh_keys/test_client.py
@@ -116,6 +116,17 @@ class TestSSHKeysClient(object):
         assert ssh_keys.id == 2323
         assert ssh_keys.name == "SSH-Key"
 
+    def test_get_by_fingerprint(self, ssh_keys_client, one_ssh_keys_response):
+        ssh_keys_client._client.request.return_value = one_ssh_keys_response
+        ssh_keys = ssh_keys_client.get_by_fingerprint("b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:2f")
+
+        params = {'fingerprint': "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:2f"}
+        ssh_keys_client._client.request.assert_called_with(url="/ssh_keys", method="GET", params=params)
+
+        assert ssh_keys._client is ssh_keys_client
+        assert ssh_keys.id == 2323
+        assert ssh_keys.name == "SSH-Key"
+
     def test_create(self, ssh_keys_client, ssh_key_response):
         ssh_keys_client._client.request.return_value = ssh_key_response
         ssh_key = ssh_keys_client.create(name="My ssh key", public_key="ssh-rsa AAAjjk76kgf...Xt")


### PR DESCRIPTION
This PR adds a new method
`client.ssh_keys.get_by_fingerprint("fingerprint")`

Which allows to get an ssh key by its fingerprint. The fingerprint is unique.

Currently this is the solution we will replace with the new method:

```python
            if self.module.params.get("fingerprint") is not None:
                result = self.client.ssh_keys.get_all(fingerprint=self.module.params.get("fingerprint"))
                if len(result) == 1:
                    self.hcloud_ssh_key = result[0]
```