### PR TITLE
Remove __init__ file from tests directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     include_package_data=True,
     keywords='hcloud hetzner cloud',
     name='hcloud',
-    packages=find_packages(exclude=["examples", "tests", "docs"]),
+    packages=find_packages(exclude=["examples", "tests*", "docs"]),
     test_suite='tests',
     url='https://github.com/hetznercloud/hcloud-python',
     version=version['VERSION'],


### PR DESCRIPTION
This should fix #40.  @asarubbo could you please test this branch?

Deleting the __init__.py as the solution for this problem was described in https://github.com/enjoy-digital/litex/issues/73.