### PR TITLE
Fix missing hcloud.networks.domain.NetworkRoute documentation

### DIFF
--- a/docs/api.clients.networks.rst
+++ b/docs/api.clients.networks.rst
@@ -14,7 +14,7 @@ NetworksClient
 .. autoclass:: hcloud.networks.domain.NetworkSubnet
     :members:
 
-.. autoclass:: hcloud.networks.domain.NetworkRoutes
+.. autoclass:: hcloud.networks.domain.NetworkRoute
     :members:
 
 .. autoclass:: hcloud.networks.domain.CreateNetworkResponse


### PR DESCRIPTION
At the moment on our docs https://hcloud-python.readthedocs.io/en/latest/api.clients.networks.html the NetworkRoute documentation is missing. This fixes the error.  