### PR TITLE
Fix servers.client._create_image error in 'labels' parameter handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+master (XXXX-XX-XX)
+-------------------
+
+* Fix: ServersClient.create_image fails when specifying the `labels`
+
 1.4.1 (2019-08-19)
 ------------------
 

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -670,7 +670,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
             data.update({"type": type})
 
         if labels is not None:
-            data.update({"type": labels})
+            data.update({"labels": labels})
 
         response = self._client.request(url="/servers/{server_id}/actions/create_image".format(server_id=server.id),
                                         method="POST", json=data)

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -651,8 +651,8 @@ class TestServersClient(object):
     @pytest.mark.parametrize("server", [Server(id=1), BoundServer(mock.MagicMock(), dict(id=1))])
     def test_create_image(self, servers_client, server, response_server_create_image):
         servers_client._client.request.return_value = response_server_create_image
-        response = servers_client.create_image(server, description="my image", type="snapshot")
-        servers_client._client.request.assert_called_with(url="/servers/1/actions/create_image", method="POST", json={"description": "my image", "type": "snapshot"})
+        response = servers_client.create_image(server, description="my image", type="snapshot", labels={"key": "value"})
+        servers_client._client.request.assert_called_with(url="/servers/1/actions/create_image", method="POST", json={"description": "my image", "type": "snapshot", "labels": {"key": "value"}})
 
         assert response.action.id == 1
         assert response.action.progress == 0


### PR DESCRIPTION
This fixes a trivial error in parameter handling that prevented image creation