### PR TITLE
Added requests.Session usage

### DIFF
--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import time
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ from hcloud import Client
 
 @pytest.fixture(autouse=True, scope='function')
 def mocked_requests():
-    patcher = mock.patch('hcloud.hcloud.requests')
+    patcher = mock.patch('hcloud.hcloud.requests.Session.request')
     mocked_requests = patcher.start()
     yield mocked_requests
     patcher.stop()


### PR DESCRIPTION
I changed code to use a `requests.Session` instead of recreate it each time.
It has several advantages:
- We have one object (`Client.session`) allowing to launch any authenticated requests
- This object use keep alive
- It can manage errors

I also removed the "manual" error handling for the `requests`'s one. And as it is already tested in their lib, I also removed the linked unit tests.