### PR TITLE
Add support for the networks parameter on server creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+master (XXXX-XX-XX)
+--------------------
+* Feature: Add support for the optional 'networks' paramater on server creation.
+
 1.6.3 (2020-01-09)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ History
 
 master (XXXX-XX-XX)
 --------------------
-* Feature: Add support for the optional 'networks' paramater on server creation.
+* Feature: Add support for the optional 'networks' parameter on server creation.
 
 1.6.3 (2020-01-09)
 --------------------

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -392,6 +392,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
                image,  # type: Image
                ssh_keys=None,  # type: Optional[List[SSHKey]]
                volumes=None,  # type: Optional[List[Volume]]
+               networks=None,  # type: Optional[List[Network]]
                user_data=None,  # type: Optional[str]
                labels=None,  # type: Optional[Dict[str, str]]
                location=None,  # type: Optional[Location]
@@ -412,6 +413,8 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
                SSH keys which should be injected into the server at creation time
         :param volumes: List[:class:`BoundVolume <hcloud.volumes.client.BoundVolume>` or :class:`Volume <hcloud.volumes.domain.Volume>`] (optional)
                Volumes which should be attached to the server at the creation time. Volumes must be in the same location.
+        :param networks: List[:class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`] (optional)
+               Network which should be attached to the server private network interface at the creation time.
         :param user_data: str (optional)
                Cloud-Init user data to use during server creation. This field is limited to 32KiB.
         :param labels: Dict[str,str] (optional)
@@ -439,6 +442,8 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
             data['ssh_keys'] = [ssh_key.id_or_name for ssh_key in ssh_keys]
         if volumes is not None:
             data['volumes'] = [volume.id for volume in volumes]
+        if networks is not None:
+            data['networks'] = [network.id for network in networks]
         if user_data is not None:
             data['user_data'] = user_data
         if labels is not None:

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -414,7 +414,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         :param volumes: List[:class:`BoundVolume <hcloud.volumes.client.BoundVolume>` or :class:`Volume <hcloud.volumes.domain.Volume>`] (optional)
                Volumes which should be attached to the server at the creation time. Volumes must be in the same location.
         :param networks: List[:class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`] (optional)
-               Network which should be attached to the server private network interface at the creation time.
+               Networks which should be attached to the server at the creation time.
         :param user_data: str (optional)
                Cloud-Init user data to use during server creation. This field is limited to 32KiB.
         :param labels: Dict[str,str] (optional)

--- a/tests/integration/servers/test_servers.py
+++ b/tests/integration/servers/test_servers.py
@@ -199,6 +199,7 @@ class TestServersClient(object):
             image=Image(name="ubuntu-16.04"),
             ssh_keys=[SSHKey(name="my-ssh-key")],
             volumes=[Volume(id=1)],
+            networks=[Network(id=1)],
             user_data="#cloud-config\\nruncmd:\\n- [touch, /root/cloud-init-worked]\\n",
             location=Location(name="nbg1"),
             automount=False

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -514,6 +514,46 @@ class TestServersClient(object):
 
         assert next_actions[0].id == 13
 
+    def test_create_with_networks(self, servers_client, response_create_simple_server):
+        servers_client._client.request.return_value = response_create_simple_server
+        networks = [Network(id=1), BoundNetwork(mock.MagicMock(), dict(id=2))]
+        response = servers_client.create(
+            "my-server",
+            server_type=ServerType(name="cx11"),
+            image=Image(id=4711),
+            networks=networks,
+            start_after_create=False
+        )
+        servers_client._client.request.assert_called_with(
+            url="/servers",
+            method="POST",
+            json={
+                'name': "my-server",
+                'server_type': "cx11",
+                'image': 4711,
+                'networks': [1, 2],
+                "start_after_create": False
+            }
+        )
+
+        bound_server = response.server
+        bound_action = response.action
+        next_actions = response.next_actions
+        root_password = response.root_password
+
+        assert root_password == "YItygq1v3GYjjMomLaKc"
+
+        assert bound_server._client is servers_client
+        assert bound_server.id == 1
+        assert bound_server.name == "my-server"
+
+        assert isinstance(bound_action, BoundAction)
+        assert bound_action._client == servers_client._client.actions
+        assert bound_action.id == 1
+        assert bound_action.command == "create_server"
+
+        assert next_actions[0].id == 13
+
     @pytest.mark.parametrize("server", [Server(id=1), BoundServer(mock.MagicMock(), dict(id=1))])
     def test_get_actions_list(self, servers_client, server, response_get_actions):
         servers_client._client.request.return_value = response_get_actions


### PR DESCRIPTION
The API allows the specification of Network IDs which should be attached to the server private network interface at creation time. However, specifying networks when creating a server is not supported by this package yet.

This PR adds an optional `networks` parameter to the `hcloud.servers.client.ServersClient.create` method and tests based on the ones for the `volumes` paramether.

Let me know, whether something needs to be adjusted. (Got late this night, better review my changes).