### PR TITLE
Add traffic properties to Load Balancer domain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+master (XXXX-XX-XX)
+--------------------
+
+* Add `included_traffic`, `outgoing_traffic` and `ingoing_traffic` properties to Load Balancer domain
 
 v1.8.2 (2020-07-20)
 --------------------

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -31,8 +31,12 @@ class LoadBalancer(BaseDomain):
             The targets the LoadBalancer is currently serving
     :param load_balancer_type: LoadBalancerType
             The type of the Load Balancer
-
-
+    :param outgoing_traffic: int, None
+           Outbound Traffic for the current billing period in bytes
+    :param ingoing_traffic: int, None
+           Inbound Traffic for the current billing period in bytes
+    :param included_traffic: int
+           Free Traffic for the current billing period in bytes
     """
 
     __slots__ = (
@@ -47,7 +51,10 @@ class LoadBalancer(BaseDomain):
         "protection",
         "labels",
         "targets",
-        "created"
+        "created",
+        "outgoing_traffic",
+        "ingoing_traffic",
+        "included_traffic",
     )
 
     def __init__(
@@ -63,7 +70,10 @@ class LoadBalancer(BaseDomain):
             protection=None,
             labels=None,
             targets=None,
-            created=None
+            created=None,
+            outgoing_traffic=None,
+            ingoing_traffic=None,
+            included_traffic=None,
     ):
         self.id = id
         self.name = name
@@ -77,6 +87,9 @@ class LoadBalancer(BaseDomain):
         self.targets = targets
         self.protection = protection
         self.labels = labels
+        self.outgoing_traffic = outgoing_traffic
+        self.ingoing_traffic = ingoing_traffic
+        self.included_traffic = included_traffic
 
 
 class LoadBalancerService(BaseDomain):

--- a/tests/unit/load_balancers/conftest.py
+++ b/tests/unit/load_balancers/conftest.py
@@ -47,6 +47,9 @@ def response_load_balancer():
             },
             "labels": {},
             "created": "2016-01-30T23:50:00+00:00",
+            "outgoing_traffic": 123456,
+            "ingoing_traffic": 123456,
+            "included_traffic": 654321,
             "services": [
                 {
                     "protocol": "https",
@@ -136,6 +139,9 @@ def response_create_load_balancer():
             "algorithm": {
                 "type": "round_robin"
             },
+            "outgoing_traffic": 123456,
+            "ingoing_traffic": 123456,
+            "included_traffic": 654321,
             "services": [
                 {
                     "protocol": "https",
@@ -219,6 +225,9 @@ def response_update_load_balancer():
                 "longitude": 12.370071,
                 "network_zone": "eu-central"
             },
+            "outgoing_traffic": 123456,
+            "ingoing_traffic": 123456,
+            "included_traffic": 654321,
             "load_balancer_type": {
                 "id": 1,
                 "name": "lb11",
@@ -324,6 +333,9 @@ def response_simple_load_balancers():
                     "longitude": 12.370071,
                     "network_zone": "eu-central"
                 },
+                "outgoing_traffic": 123456,
+                "ingoing_traffic": 123456,
+                "included_traffic": 654321,
                 "load_balancer_type": {
                     "id": 1,
                     "name": "lb11",
@@ -448,6 +460,9 @@ def response_simple_load_balancers():
                 },
                 "labels": {},
                 "created": "2016-01-30T23:50:00+00:00",
+                "outgoing_traffic": 123456,
+                "ingoing_traffic": 123456,
+                "included_traffic": 654321,
                 "services": [
                     {
                         "protocol": "https",

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -220,6 +220,9 @@ class TestLoadBalancerslient(object):
         assert bound_load_balancer._client is load_balancers_client
         assert bound_load_balancer.id == 4711
         assert bound_load_balancer.name == "Web Frontend"
+        assert bound_load_balancer.outgoing_traffic == 123456
+        assert bound_load_balancer.ingoing_traffic == 123456
+        assert bound_load_balancer.included_traffic == 654321
 
     @pytest.mark.parametrize(
         "params",


### PR DESCRIPTION
Add `included_traffic`, `outgoing_traffic` and `ingoing_traffic` properties to Load Balancer domain