### PR TITLE
Add primary_disk_size to Server domain

### DIFF
--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -33,6 +33,8 @@ class Server(BaseDomain):
            Inbound Traffic for the current billing period in bytes
     :param included_traffic: int
            Free Traffic for the current billing period in bytes
+    :param primary_disk_size: int
+           Size of the primary Disk
     :param protection: dict
            Protection configuration for the server
     :param labels: dict
@@ -79,7 +81,8 @@ class Server(BaseDomain):
         "labels",
         "volumes",
         "private_net",
-        "created"
+        "created",
+        "primary_disk_size"
     )
 
     def __init__(
@@ -103,6 +106,7 @@ class Server(BaseDomain):
             labels=None,
             volumes=None,
             private_net=None,
+            primary_disk_size=None
     ):
         self.id = id
         self.name = name
@@ -123,6 +127,7 @@ class Server(BaseDomain):
         self.labels = labels
         self.volumes = volumes
         self.private_net = private_net
+        self.primary_disk_size = primary_disk_size
 
 
 class CreateServerResponse(BaseDomain):

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -106,7 +106,7 @@ class Server(BaseDomain):
             labels=None,
             volumes=None,
             private_net=None,
-            primary_disk_size=None
+            primary_disk_size=None,
     ):
         self.id = id
         self.name = name

--- a/tests/unit/servers/conftest.py
+++ b/tests/unit/servers/conftest.py
@@ -122,6 +122,7 @@ def response_simple_server():
             "outgoing_traffic": 123456,
             "ingoing_traffic": 123456,
             "included_traffic": 654321,
+            "primary_disk_size" 20,
             "protection": {},
             "labels": {},
             "volumes": []

--- a/tests/unit/servers/conftest.py
+++ b/tests/unit/servers/conftest.py
@@ -122,7 +122,7 @@ def response_simple_server():
             "outgoing_traffic": 123456,
             "ingoing_traffic": 123456,
             "included_traffic": 654321,
-            "primary_disk_size" 20,
+            "primary_disk_size": 20,
             "protection": {},
             "labels": {},
             "volumes": []

--- a/tests/unit/servers/conftest.py
+++ b/tests/unit/servers/conftest.py
@@ -138,6 +138,7 @@ def response_create_simple_server():
             "name": "my-server",
             "status": "running",
             "created": "2016-01-30T23:50+00:00",
+            "primary_disk_size": 20,
             "public_net": {
                 "ipv4": {
                     "ip": "1.2.3.4",
@@ -662,6 +663,7 @@ def response_simple_servers():
             "outgoing_traffic": 123456,
             "ingoing_traffic": 123456,
             "included_traffic": 654321,
+            "primary_disk_size": 20,
             "protection": {},
             "labels": {},
             "volumes": []
@@ -677,6 +679,7 @@ def response_full_server():
             "name": "my-server",
             "status": "running",
             "created": "2016-01-30T23:50+00:00",
+            "primary_disk_size": 20,
             "public_net": {
                 "ipv4": {
                     "ip": "1.2.3.4",

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -35,6 +35,7 @@ class TestBoundServer(object):
 
         assert bound_server.id == 42
         assert bound_server.name == "my-server"
+        assert bound_server.primary_disk_size == 20
         assert isinstance(bound_server.public_net, PublicNetwork)
         assert isinstance(bound_server.public_net.ipv4, IPv4Address)
         assert bound_server.public_net.ipv4.ip == "1.2.3.4"


### PR DESCRIPTION
API provides a field named `primary_disk_size` for servers which was missing.

This field is important if you want to check the possibility of a downgrade for a server.

https://docs.hetzner.cloud/#servers-get-a-server