### PR TITLE
Use requests Session for persistent HTTPS connections

### DIFF
--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -60,6 +60,7 @@ class Client(object):
         self._application_name = application_name
         self._application_version = application_version
         self.poll_interval = poll_interval
+        self.requests_session = requests.Session()
 
         self.datacenters = DatacentersClient(self)
         """DatacentersClient Instance
@@ -195,7 +196,7 @@ class Client(object):
         :return: Response
         :rtype: requests.Response
         """
-        response = requests.request(
+        response = self.requests_session.request(
             method,
             self._api_endpoint + url,
             headers=self._get_headers(),


### PR DESCRIPTION
Fixes #114

Change `hcloud.Client` to create a [`requests.Session`](https://docs.python-requests.org/en/latest/user/advanced/#session-objects) object and use it for all requests. This enables the use of connection pooling with persistent HTTP connections, reducing the HTTPS connection overhead for multiple requests using the same Client instance.