### PR TITLE
Use requests Session for persistent HTTPS connections

### DIFF
--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -59,6 +59,7 @@ class Client(object):
         self._api_endpoint = api_endpoint
         self._application_name = application_name
         self._application_version = application_version
+        self._requests_session = requests.Session()
         self.poll_interval = poll_interval
 
         self.datacenters = DatacentersClient(self)
@@ -195,7 +196,7 @@ class Client(object):
         :return: Response
         :rtype: requests.Response
         """
-        response = requests.request(
+        response = self._requests_session.request(
             method,
             self._api_endpoint + url,
             headers=self._get_headers(),


### PR DESCRIPTION
hcloud.Client now reuses the underlying TCP connection instead of establishing a new connection on every request. This was initially found in https://github.com/hetznercloud/hcloud-python/pull/123. This commit superseeds the mentioned MR and fixes the tests.


This was initially found by @SpComb in https://github.com/hetznercloud/hcloud-python/pull/123

Fixes #114
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>