### PR TITLE
document installation path via conda-forge

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,10 +23,10 @@ you through the process.
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 
 
-Via conda
+Via conda (Third-Party)
 ---------
 
-Hetzner Cloud Python is also available as a ``conda``-package via `conda-forge`_:
+Hetzner Cloud Python is also available as a ``conda``-package via `conda-forge`. This package is not maintained by Hetzner Cloud and might be outdated._:
 
 .. code-block:: console
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,18 @@ you through the process.
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 
 
+Via conda
+---------
+
+Hetzner Cloud Python is also available as a ``conda``-package via `conda-forge`_:
+
+.. code-block:: console
+
+    $ conda install -c conda-forge hcloud
+
+.. _conda-forge: https://conda-forge.org/
+
+
 From sources
 ------------
 


### PR DESCRIPTION
This PR documents an alternative method of installation via [conda-forge](https://conda-forge.org/). Driving some additional customers your way ;) See #113.