### PR TITLE
Remove use of external mock module

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@
 
 flake8==3.6.0
 isort==4.3.4
-mock==2.0.0
 pytest
 tox==3.23.1
 black==21.7b0

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from hcloud.actions.client import ActionsClient, BoundAction

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from hcloud.actions.client import BoundAction
 from hcloud.certificates.client import CertificatesClient, BoundCertificate

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from hcloud import Client
 

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin

--- a/tests/unit/datacenters/test_client.py
+++ b/tests/unit/datacenters/test_client.py
@@ -1,5 +1,5 @@
 import pytest  # noqa: F401
-import mock  # noqa: F401
+from unittest import mock  # noqa: F401
 
 from hcloud.datacenters.client import DatacentersClient, BoundDatacenter
 from hcloud.datacenters.domain import DatacenterServerTypes

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from hcloud.firewalls.client import FirewallsClient, BoundFirewall
 from hcloud.actions.client import BoundAction

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from hcloud.actions.client import BoundAction
 from hcloud.servers.client import BoundServer

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import datetime
 from dateutil.tz import tzoffset
 

--- a/tests/unit/isos/test_client.py
+++ b/tests/unit/isos/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import datetime
 from dateutil.tz import tzoffset
 

--- a/tests/unit/load_balancer_types/test_client.py
+++ b/tests/unit/load_balancer_types/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 
 from hcloud.load_balancer_types.client import LoadBalancerTypesClient

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from hcloud.load_balancer_types.domain import LoadBalancerType

--- a/tests/unit/locations/test_client.py
+++ b/tests/unit/locations/test_client.py
@@ -1,5 +1,5 @@
 import pytest  # noqa: F401
-import mock  # noqa: F401
+from unittest import mock  # noqa: F401
 
 from hcloud.locations.client import LocationsClient
 

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -1,6 +1,6 @@
 import pytest
 from dateutil.parser import isoparse
-import mock
+from unittest import mock
 
 from hcloud.actions.client import BoundAction
 from hcloud.networks.client import BoundNetwork, NetworksClient

--- a/tests/unit/placement_groups/test_client.py
+++ b/tests/unit/placement_groups/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from hcloud.placement_groups.client import BoundPlacementGroup, PlacementGroupsClient
 

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from hcloud.primary_ips.client import PrimaryIPsClient, BoundPrimaryIP
 from hcloud.primary_ips.domain import PrimaryIP

--- a/tests/unit/server_types/test_client.py
+++ b/tests/unit/server_types/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 
 from hcloud.server_types.client import ServerTypesClient

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from hcloud.firewalls.client import BoundFirewall

--- a/tests/unit/ssh_keys/test_client.py
+++ b/tests/unit/ssh_keys/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from hcloud.ssh_keys.client import SSHKeysClient, BoundSSHKey
 from hcloud.ssh_keys.domain import SSHKey

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -1,6 +1,6 @@
 import pytest
 from dateutil.parser import isoparse
-import mock
+from unittest import mock
 
 from hcloud.actions.client import BoundAction
 from hcloud.servers.client import BoundServer


### PR DESCRIPTION
Python since 3.4 has included mock in the standard library, under the
unittest module. Since the lowest version supported is greater than
that, we can switch to using it and drop one external requirement.