### PR TITLE
Add validation helper for Label Values/Keys

### DIFF
--- a/docs/api.helpers.rst
+++ b/docs/api.helpers.rst
@@ -1,0 +1,7 @@
+Helpers
+==================
+
+
+.. autoclass:: hcloud.helpers.labels.LabelValidator
+    :members:
+

--- a/hcloud/helpers/labels.py
+++ b/hcloud/helpers/labels.py
@@ -1,0 +1,39 @@
+import re
+from typing import Dict
+
+
+class LabelValidator:
+    KEY_REGEX = re.compile(
+        "^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,62}[a-z0-9A-Z])?$"
+    )
+    VALUE_REGEX = re.compile(
+        "^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,62})?[a-z0-9A-Z]$|$)"
+    )
+
+    @staticmethod
+    def validate(labels: Dict[str, str]) -> bool:
+        """Validates Labels. If you want to know which key/value pair of the dict is not correctly formatted
+        use :func:`~hcloud.helpers.labels.validate_verbose`.
+
+        :return:  bool
+        """
+        for k, v in labels.items():
+            if LabelValidator.KEY_REGEX.match(k) is None:
+                return False
+            if LabelValidator.VALUE_REGEX.match(v) is None:
+                return False
+        return True
+
+    @staticmethod
+    def validate_verbose(labels: Dict[str, str]) -> (bool, str):
+        """Validates Labels and returns the corresponding error message if something is wrong. Returns True, <empty string>
+        if everything is fine.
+
+        :return:  bool, str
+        """
+        for k, v in labels.items():
+            if LabelValidator.KEY_REGEX.match(k) is None:
+                return False, f"label key {k} is not correctly formatted"
+            if LabelValidator.VALUE_REGEX.match(v) is None:
+                return False, f"label value {v} (key: {k}) is not correctly formatted"
+        return True, ""

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -404,7 +404,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         public_interface=None,  # type: Optional[bool]
         network=None,  # type: Optional[Union[Network,BoundNetwork]]
     ):
-        # type: (...) -> CreateLoadBalancerResponse:
+        # type: (...) -> CreateLoadBalancerResponse
         """Creates a Load Balancer .
 
         :param name: str

--- a/tests/unit/helpers/test_labels.py
+++ b/tests/unit/helpers/test_labels.py
@@ -1,0 +1,119 @@
+import pytest
+
+from hcloud.helpers.labels import LabelValidator
+
+
+@pytest.mark.parametrize(
+    "labels,expected",
+    [
+        # valid combinations
+        ({"label1": "correct.de"}, True),
+        ({"empty/label": ""}, True),
+        ({"label3-test.de/hallo.welt": "233344444443"}, True),
+        ({"label2.de/hallo": "1correct2.de"}, True),
+        # invalid value
+        ({"valid_key": "incorrect .com"}, False),
+        ({"valid_key": "-incorrect.com"}, False),
+        ({"valid_key": "incorrect.com-"}, False),
+        ({"valid_key": "incorr,ect.com-"}, False),
+        (
+            {
+                "valid_key": "incorrect-111111111111111111111111111111111111111111111111111111111111.com"
+            },
+            False,
+        ),
+        # invalid keys
+        ({"incorrect.de/": "correct.de"}, False),
+        ({"incor rect.de/": "correct.de"}, False),
+        ({"incorrect.de/+": "correct.de"}, False),
+        ({"-incorrect.de": "correct.de"}, False),
+        ({"incorrect.de-": "correct.de"}, False),
+        ({"incorrect.de/tes t": "correct.de"}, False),
+        ({"incorrect.de/test-": "correct.de"}, False),
+        (
+            {
+                "incorrect.de/test-dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd": "correct.de"
+            },
+            False,
+        ),
+        (
+            {
+                "incorrect-11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + ".de/test": "correct.de"
+            },
+            False,
+        ),
+    ],
+)
+def test_validate(labels, expected):
+    assert LabelValidator.validate(labels=labels) == expected
+
+
+@pytest.mark.parametrize(
+    "labels,expected,type",
+    [
+        # valid combinations
+        ({"label1": "correct.de"}, True, ""),
+        ({"empty/label": ""}, True, ""),
+        ({"label3-test.de/hallo.welt": "233344444443"}, True, ""),
+        ({"label2.de/hallo": "1correct2.de"}, True, ""),
+        # invalid value
+        ({"valid_key": "incorrect .com"}, False, "value"),
+        ({"valid_key": "-incorrect.com"}, False, "value"),
+        ({"valid_key": "incorrect.com-"}, False, "value"),
+        ({"valid_key": "incorr,ect.com-"}, False, "value"),
+        (
+            {
+                "valid_key": "incorrect-111111111111111111111111111111111111111111111111111111111111.com"
+            },
+            False,
+            "value",
+        ),
+        # invalid keys
+        ({"incorrect.de/": "correct.de"}, False, "key"),
+        ({"incor rect.de/": "correct.de"}, False, "key"),
+        ({"incorrect.de/+": "correct.de"}, False, "key"),
+        ({"-incorrect.de": "correct.de"}, False, "key"),
+        ({"incorrect.de-": "correct.de"}, False, "key"),
+        ({"incorrect.de/tes t": "correct.de"}, False, "key"),
+        ({"incorrect.de/test-": "correct.de"}, False, "key"),
+        (
+            {
+                "incorrect.de/test-dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd": "correct.de"
+            },
+            False,
+            "key",
+        ),
+        (
+            {
+                "incorrect-11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + "11111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                + ".de/test": "correct.de"
+            },
+            False,
+            "key",
+        ),
+    ],
+)
+def test_validate_verbose(labels, expected, type):
+    result, error = LabelValidator.validate_verbose(labels=labels)
+    if type == "key" and expected is False:
+        assert error == f"label key {list(labels.keys())[0]} is not correctly formatted"
+    elif type == "value" and expected is False:
+        assert (
+            error
+            == f"label value {list(labels.values())[0]} (key: {list(labels.keys())[0]}) is not correctly formatted"
+        )
+
+    assert result == expected

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py36, py37, py38, py39, py310, flake8
 
 [testenv:flake8]
 basepython = python
-deps = flake8==3.6.0
-commands = flake8 hcloud tests setup.py
+deps = flake8==5.0.4
+commands = flake8 --ignore F821,E501,W605,W503 hcloud tests setup.py
 
 [testenv:black]
 basepython = python


### PR DESCRIPTION
This implementation is similar to the implementation in the hcloud-go. To give the "user" as much as verbosity as possible i introduced two methods.

- `validate` which is a simple validator that just returns True/False
- `validate_verbose` which also returns the corresponding error message (like which key/value is not correctly formatted)

I decided against calling one of both function in the other and instead duplicate the code. This is based on my feeling that the code would be more complex when we as a sample call validate_verbose in validate. Also, it is slightly more readable imho, but we can discuss this :)

Closes https://github.com/hetznercloud/hcloud-python/issues/153

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>