### PR TITLE
fix: allow omitting `datacenter` when creating a primary ip

### DIFF
--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -178,7 +178,8 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
     def create(
         self,
         type: str,
-        datacenter: Datacenter | BoundDatacenter,
+        # TODO: Make the datacenter argument optional
+        datacenter: Datacenter | BoundDatacenter | None,
         name: str,
         assignee_type: str | None = "server",
         assignee_id: int | None = None,
@@ -203,12 +204,12 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
             "type": type,
             "assignee_type": assignee_type,
             "auto_delete": auto_delete,
-            "datacenter": datacenter.id_or_name,
             "name": name,
         }
-        if assignee_id:
+        if datacenter is not None:
+            data["datacenter"] = datacenter.id_or_name
+        if assignee_id is not None:
             data["assignee_id"] = assignee_id
-            data.pop("datacenter")
         if labels is not None:
             data["labels"] = labels
 

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -208,6 +208,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         }
         if assignee_id:
             data["assignee_id"] = assignee_id
+            data.pop("datacenter")
         if labels is not None:
             data["labels"] = labels
 


### PR DESCRIPTION
As the public api document states for Datacenter: "ID or name of Datacenter the Primary IP will be bound to. Needs to be **omitted** if assignee_id is passed.".
since passing the `datacenter` argument to `create` method is required, if you also pass the `assignee_id`, you will get this error:
`in _raise_exception_from_json_content
    raise APIException(
hcloud.hcloud.APIException: invalid input in fields 'assignee_id', 'datacenter'`.
so i think the solution is `if assignee_id exist: pop the datacenter from data`.