### PR TITLE
fix: remove unused future dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("CHANGELOG.rst") as changelog_file:
     changelog = changelog_file.read()
 
-requirements = ["future>=0.17.1", "python-dateutil>=2.7.5", "requests>=2.20"]
+requirements = ["python-dateutil>=2.7.5", "requests>=2.20"]
 
 extras_require = {"docs": ["Sphinx==1.8.1", "sphinx-rtd-theme==0.4.2"]}
 


### PR DESCRIPTION
As far as I can tell, we never used this dependency. We only support Python 3+, and the dependency has a known vulnerability and is not maintained.

There is not reason for us to keep it, and we were requested to remove it in #172.