### PR TITLE
docs: link to PrivateNet broken

### DIFF
--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -40,7 +40,7 @@ class Server(BaseDomain):
             User-defined labels (key-value pairs)
     :param volumes: List[:class:`BoundVolume <hcloud.volumes.client.BoundVolume>`]
             Volumes assigned to this server.
-    :param private_net: List[:class:`PrivateNet <hcloud.servers.domain.PrivateNet`]
+    :param private_net: List[:class:`PrivateNet <hcloud.servers.domain.PrivateNet>`]
             Private networks information.
     """
 


### PR DESCRIPTION
Missing `>` causes link in docs to break: https://hcloud-python.readthedocs.io/en/stable/api.clients.servers.html#hcloud.servers.domain.Server