### PR TITLE
Include *.js *.svg static assets in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,4 @@ recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif *.js *.svg


### PR DESCRIPTION
Extend the include for documentation assets to `*.js` and `*.svg` files,
to fix building documentation from sdist archives.
