### PR TITLE
feat(server_type): add field for included traffic

### DIFF
--- a/hcloud/server_types/domain.py
+++ b/hcloud/server_types/domain.py
@@ -23,9 +23,11 @@ class ServerType(BaseDomain, DomainIdentityMixin):
     :param cpu_type: string
            Type of cpu. Choices: `shared`, `dedicated`
     :param architecture: string
-            Architecture of cpu. Choices: `x86`, `arm`
+           Architecture of cpu. Choices: `x86`, `arm`
     :param deprecated: bool
            True if server type is deprecated
+    :param included_traffic: int
+           Free traffic per month in bytes
     """
 
     __slots__ = (
@@ -40,6 +42,7 @@ class ServerType(BaseDomain, DomainIdentityMixin):
         "cpu_type",
         "architecture",
         "deprecated",
+        "included_traffic",
     )
 
     def __init__(
@@ -55,6 +58,7 @@ class ServerType(BaseDomain, DomainIdentityMixin):
         cpu_type=None,
         architecture=None,
         deprecated=None,
+        included_traffic=None,
     ):
         self.id = id
         self.name = name
@@ -67,3 +71,4 @@ class ServerType(BaseDomain, DomainIdentityMixin):
         self.cpu_type = cpu_type
         self.architecture = architecture
         self.deprecated = deprecated
+        self.included_traffic = included_traffic

--- a/tests/unit/server_types/conftest.py
+++ b/tests/unit/server_types/conftest.py
@@ -27,6 +27,7 @@ def server_type_response():
             "storage_type": "local",
             "cpu_type": "shared",
             "architecture": "x86",
+            "included_traffic": 21990232555520,
         }
     }
 
@@ -58,6 +59,7 @@ def two_server_types_response():
                 "storage_type": "local",
                 "cpu_type": "shared",
                 "architecture": "x86",
+                "included_traffic": 21990232555520,
             },
             {
                 "id": 2,
@@ -93,6 +95,7 @@ def two_server_types_response():
                 "storage_type": "local",
                 "cpu_type": "shared",
                 "architecture": "x86",
+                "included_traffic": 21990232555520,
             },
         ]
     }
@@ -125,6 +128,7 @@ def one_server_types_response():
                 "storage_type": "local",
                 "cpu_type": "shared",
                 "architecture": "x86",
+                "included_traffic": 21990232555520,
             }
         ]
     }

--- a/tests/unit/server_types/test_client.py
+++ b/tests/unit/server_types/test_client.py
@@ -24,6 +24,7 @@ class TestBoundIso(object):
         assert bound_server_type.storage_type == "local"
         assert bound_server_type.cpu_type == "shared"
         assert bound_server_type.architecture == "x86"
+        assert bound_server_type.included_traffic == 21990232555520
 
 
 class TestServerTypesClient(object):


### PR DESCRIPTION
Field was recently added to the API: https://docs.hetzner.cloud/#server-types