### PR TITLE
ci: setup release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+
+jobs:
+  release-please:
+    # The secret HCLOUD_BOT_TOKEN is only available on the main repo, not in forks.
+    if: github.repository == 'hetznercloud/hcloud-python'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          token: ${{ secrets.HCLOUD_BOT_TOKEN }}
+          release-type: python
+          package-name: hcloud
+
+          extra-files: |
+            hcloud/__version__.py

--- a/hcloud/__version__.py
+++ b/hcloud/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "1.19.0"
+VERSION = "1.19.0"  # x-release-please-version


### PR DESCRIPTION
Setup release-please to automate creating new tags according to semver rules.

---

### Changelog

The changelog for this project has used RST as the format, but hasnt been filled for a while. We currently add the changelog to the pypi page. Release-please only supports markdown changelogs, so we will get another file `CHANGELOG.md` (in addition to `CHANGELOG.rst`) with the up to date changelog.

As this is outdated/broken right now, I dont plan on fixing it for this PR. Later we could migrate the full changelog to markdown and either only link to it in pypi, or convert it to rst before publishing.