### PR TITLE
Bug in hcloud-inventory: one server without public ip4v crashes the complete plugin

### DIFF
--- a/hcloud/core/domain.py
+++ b/hcloud/core/domain.py
@@ -6,6 +6,8 @@ class BaseDomain(object):
 
     @classmethod
     def from_dict(cls, data):
+        if data is None:
+            return None
         supported_data = {k: v for k, v in data.items() if k in cls.__slots__}
         return cls(**supported_data)
 


### PR DESCRIPTION
This lines fixes: 
When there is only one server in the hetzner environment, that has no public ipv4, than the hcloud-inventory is not working and returns an empty host list.

```
client.servers.get_all() produces:
Traceback (most recent call last):
  File "/xx/test.py", line 6, in <module>
    servers = client.servers.get_all()
  File "/usr/lib/python3.9/site-packages/hcloud/servers/client.py", line 452, in get_all
    return super(ServersClient, self).get_all(
  File "/usr/lib/python3.9/site-packages/hcloud/core/client.py", line 68, in get_all
    return self._get_all(
  File "/usr/lib/python3.9/site-packages/hcloud/core/client.py", line 46, in _get_all
    page_result = list_function(
  File "/usr/lib/python3.9/site-packages/hcloud/servers/client.py", line 435, in get_list
    ass_servers = [
  File "/usr/lib/python3.9/site-packages/hcloud/servers/client.py", line 436, in <listcomp>
    BoundServer(self, server_data) for server_data in response["servers"]
  File "/usr/lib/python3.9/site-packages/hcloud/servers/client.py", line 64, in __init__
    ipv4_address = IPv4Address.from_dict(public_net["ipv4"])
  File "/usr/lib/python3.9/site-packages/hcloud/core/domain.py", line 13, in from_dict
    supported_data = {k: v for k, v in data.items() if k in cls.__slots__}
AttributeError: 'NoneType' object has no attribute 'items'
```