### PR TITLE
fix: adjust label validation for max length of 63 characters

### DIFF
--- a/hcloud/helpers/labels.py
+++ b/hcloud/helpers/labels.py
@@ -4,10 +4,10 @@ from typing import Dict
 
 class LabelValidator:
     KEY_REGEX = re.compile(
-        "^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,62}[a-z0-9A-Z])?$"
+        "^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,61}[a-z0-9A-Z])?$"
     )
     VALUE_REGEX = re.compile(
-        "^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,62})?[a-z0-9A-Z]$|$)"
+        "^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,61})?[a-z0-9A-Z]$|$)"
     )
 
     @staticmethod

--- a/tests/unit/helpers/test_labels.py
+++ b/tests/unit/helpers/test_labels.py
@@ -22,6 +22,12 @@ from hcloud.helpers.labels import LabelValidator
             },
             False,
         ),
+        (
+            {
+                "valid_key": "63-characters-are-allowed-in-a-label__this-is-one-character-more",
+            },
+            False,
+        ),
         # invalid keys
         ({"incorrect.de/": "correct.de"}, False),
         ({"incor rect.de/": "correct.de"}, False),
@@ -71,6 +77,13 @@ def test_validate(labels, expected):
         (
             {
                 "valid_key": "incorrect-111111111111111111111111111111111111111111111111111111111111.com"
+            },
+            False,
+            "value",
+        ),
+        (
+            {
+                "valid_key": "63-characters-are-allowed-in-a-label__this-is-one-character-more",
             },
             False,
             "value",


### PR DESCRIPTION
Related to https://github.com/hetznercloud/hcloud-go/pull/273