### PR TITLE
chore: prettier breaks the release-please changelog format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     hooks:
       - id: prettier
         files: \.(md|ya?ml|js|css)$
+        exclude: ^CHANGELOG.md$
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.20.0](https://github.com/hetznercloud/hcloud-python/compare/v1.19.0...v1.20.0) (2023-05-12)
 
+
 ### Features
 
-- **server_type:** add field for included traffic ([#185](https://github.com/hetznercloud/hcloud-python/issues/185)) ([8ae0bc6](https://github.com/hetznercloud/hcloud-python/commit/8ae0bc6e032440538f3aeb2222a9bee34adab04b))
+ * **server_type:** add field for included traffic ([#185](https://github.com/hetznercloud/hcloud-python/issues/185)) ([8ae0bc6](https://github.com/hetznercloud/hcloud-python/commit/8ae0bc6e032440538f3aeb2222a9bee34adab04b))


### PR DESCRIPTION
Overriding the release-please templates is not yet supported, but might be a good idea to be able to comply with prettier's markdown styling.