### PR TITLE
feat: bump required python version to >=3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">3.5",
+    python_requires=">=3.7",
     description="Official Hetzner Cloud python library",
     install_requires=requirements,
     extras_require=extras_require,


### PR DESCRIPTION
The code already expect us to have python >=3.7.

This makes it official, and prevents older version of python to install newer version of the library.

Python 3.7 is EOL in few days https://devguide.python.org/versions/#versions.