### PR TITLE
feat: setup exception hierarchy

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,7 +19,13 @@ API Clients
 Exceptions
 ---------------
 
+.. autoclass:: hcloud.HCloudException
+    :members:
+
 .. autoclass:: hcloud.APIException
+    :members:
+
+.. autoclass:: hcloud.actions.domain.ActionException
     :members:
 
 .. autoclass:: hcloud.actions.domain.ActionFailedException

--- a/hcloud/__init__.py
+++ b/hcloud/__init__.py
@@ -1,2 +1,2 @@
-from ._exceptions import HCloudException  # noqa
-from .hcloud import APIException, Client  # noqa
+from ._exceptions import APIException, HCloudException  # noqa
+from .hcloud import Client  # noqa

--- a/hcloud/__init__.py
+++ b/hcloud/__init__.py
@@ -1,1 +1,2 @@
+from ._exceptions import HCloudException  # noqa
 from .hcloud import APIException, Client  # noqa

--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -1,2 +1,14 @@
 class HCloudException(Exception):
     """There was an error while using the hcloud library"""
+
+
+class APIException(HCloudException):
+    """There was an error while performing an API Request"""
+
+    def __init__(self, code, message, details):
+        self.code = code
+        self.message = message
+        self.details = details
+
+    def __str__(self):
+        return self.message

--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -1,0 +1,2 @@
+class HCloudException(Exception):
+    """There was an error while using the hcloud library"""

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -70,4 +70,4 @@ class ActionFailedException(ActionException):
 
 
 class ActionTimeoutException(ActionException):
-    """The Action you was waiting for timed out"""
+    """The Action you were waiting for timed out"""

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -70,4 +70,4 @@ class ActionFailedException(ActionException):
 
 
 class ActionTimeoutException(ActionException):
-    """The Action you was waiting for timeouted in hcloud-python."""
+    """The Action you was waiting for timed out"""

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -66,7 +66,7 @@ class ActionException(HCloudException):
 
 
 class ActionFailedException(ActionException):
-    """The Action you was waiting for failed"""
+    """The Action you were waiting for failed"""
 
 
 class ActionTimeoutException(ActionException):

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -2,6 +2,8 @@ from dateutil.parser import isoparse
 
 from hcloud.core.domain import BaseDomain
 
+from .._exceptions import HCloudException
+
 
 class Action(BaseDomain):
     """Action Domain
@@ -56,15 +58,16 @@ class Action(BaseDomain):
         self.error = error
 
 
-class ActionFailedException(Exception):
+class ActionException(HCloudException):
+    """A generic action exception"""
+
+    def __init__(self, action):
+        self.action = action
+
+
+class ActionFailedException(ActionException):
     """The Action you was waiting for failed"""
 
-    def __init__(self, action):
-        self.action = action
 
-
-class ActionTimeoutException(Exception):
+class ActionTimeoutException(ActionException):
     """The Action you was waiting for timeouted in hcloud-python."""
-
-    def __init__(self, action):
-        self.action = action

--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -21,19 +21,7 @@ from hcloud.ssh_keys.client import SSHKeysClient
 from hcloud.volumes.client import VolumesClient
 
 from .__version__ import VERSION
-from ._exceptions import HCloudException
-
-
-class APIException(HCloudException):
-    """There was an error while performing an API Request"""
-
-    def __init__(self, code, message, details):
-        self.code = code
-        self.message = message
-        self.details = details
-
-    def __str__(self):
-        return self.message
+from ._exceptions import APIException
 
 
 class Client:

--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -21,9 +21,10 @@ from hcloud.ssh_keys.client import SSHKeysClient
 from hcloud.volumes.client import VolumesClient
 
 from .__version__ import VERSION
+from ._exceptions import HCloudException
 
 
-class APIException(Exception):
+class APIException(HCloudException):
     """There was an error while performing an API Request"""
 
     def __init__(self, code, message, details):


### PR DESCRIPTION
We want to be able to catch some family of exception, without having to rely on the way too broad `Exception`.

This adds a hierarchy in the exception that might be raised by this library.
- HCloudException
  - APIException
  - ActionException
    - ActionFailedException
    - ActionTimeoutException
