### PR TITLE
feat: remove python-dateutil dependency

### DIFF
--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -52,8 +52,8 @@ class Action(BaseDomain):
 
         self.status = status
         self.progress = progress
-        self.started = isoparse(started) if started else None
-        self.finished = isoparse(finished) if finished else None
+        self.started = datetime.fromisoformat(started) if started else None
+        self.finished = datetime.fromisoformat(finished) if finished else None
         self.resources = resources
         self.error = error
 

--- a/hcloud/certificates/domain.py
+++ b/hcloud/certificates/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain, DomainIdentityMixin
 
@@ -59,9 +59,13 @@ class Certificate(BaseDomain, DomainIdentityMixin):
         self.certificate = certificate
         self.domain_names = domain_names
         self.fingerprint = fingerprint
-        self.not_valid_before = isoparse(not_valid_before) if not_valid_before else None
-        self.not_valid_after = isoparse(not_valid_after) if not_valid_after else None
-        self.created = isoparse(created) if created else None
+        self.not_valid_before = (
+            datetime.fromisoformat(not_valid_before) if not_valid_before else None
+        )
+        self.not_valid_after = (
+            datetime.fromisoformat(not_valid_after) if not_valid_after else None
+        )
+        self.created = datetime.fromisoformat(created) if created else None
         self.labels = labels
         self.status = status
 

--- a/hcloud/deprecation/domain.py
+++ b/hcloud/deprecation/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -25,7 +25,7 @@ class DeprecationInfo(BaseDomain):
         announced=None,
         unavailable_after=None,
     ):
-        self.announced = isoparse(announced) if announced else None
+        self.announced = datetime.fromisoformat(announced) if announced else None
         self.unavailable_after = (
-            isoparse(unavailable_after) if unavailable_after else None
+            datetime.fromisoformat(unavailable_after) if unavailable_after else None
         )

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -30,7 +30,7 @@ class Firewall(BaseDomain):
         self.rules = rules
         self.applied_to = applied_to
         self.labels = labels
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
 
 
 class FirewallRule:

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -72,7 +72,7 @@ class FloatingIP(BaseDomain):
         self.blocked = blocked
         self.protection = protection
         self.labels = labels
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.name = name
 
 

--- a/hcloud/images/domain.py
+++ b/hcloud/images/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain, DomainIdentityMixin
 
@@ -85,11 +85,11 @@ class Image(BaseDomain, DomainIdentityMixin):
         self.id = id
         self.name = name
         self.type = type
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.description = description
         self.image_size = image_size
         self.disk_size = disk_size
-        self.deprecated = isoparse(deprecated) if deprecated else None
+        self.deprecated = datetime.fromisoformat(deprecated) if deprecated else None
         self.bound_to = bound_to
         self.os_flavor = os_flavor
         self.os_version = os_version

--- a/hcloud/isos/domain.py
+++ b/hcloud/isos/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain, DomainIdentityMixin
 
@@ -36,4 +36,4 @@ class Iso(BaseDomain, DomainIdentityMixin):
         self.type = type
         self.architecture = architecture
         self.description = description
-        self.deprecated = isoparse(deprecated) if deprecated else None
+        self.deprecated = datetime.fromisoformat(deprecated) if deprecated else None

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -76,7 +76,7 @@ class LoadBalancer(BaseDomain):
     ):
         self.id = id
         self.name = name
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.public_net = public_net
         self.private_net = private_net
         self.location = location

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -54,7 +54,7 @@ class Network(BaseDomain):
     ):
         self.id = id
         self.name = name
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.ip_range = ip_range
         self.subnets = subnets
         self.routes = routes

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -35,7 +35,7 @@ class PlacementGroup(BaseDomain):
         self.labels = labels
         self.servers = servers
         self.type = type
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
 
 
 class CreatePlacementGroupResponse(BaseDomain):

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -74,7 +74,7 @@ class PrimaryIP(BaseDomain):
         self.blocked = blocked
         self.protection = protection
         self.labels = labels
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.name = name
         self.assignee_id = assignee_id
         self.assignee_type = assignee_type

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain
 
@@ -113,7 +113,7 @@ class Server(BaseDomain):
         self.id = id
         self.name = name
         self.status = status
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.public_net = public_net
         self.server_type = server_type
         self.datacenter = datacenter

--- a/hcloud/ssh_keys/domain.py
+++ b/hcloud/ssh_keys/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain, DomainIdentityMixin
 
@@ -36,4 +36,4 @@ class SSHKey(BaseDomain, DomainIdentityMixin):
         self.fingerprint = fingerprint
         self.public_key = public_key
         self.labels = labels
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None

--- a/hcloud/volumes/domain.py
+++ b/hcloud/volumes/domain.py
@@ -1,4 +1,4 @@
-from dateutil.parser import isoparse
+from datetime import datetime
 
 from hcloud.core.domain import BaseDomain, DomainIdentityMixin
 
@@ -66,7 +66,7 @@ class Volume(BaseDomain, DomainIdentityMixin):
         self.id = id
         self.name = name
         self.server = server
-        self.created = isoparse(created) if created else None
+        self.created = datetime.fromisoformat(created) if created else None
         self.location = location
         self.size = size
         self.linux_device = linux_device

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "python-dateutil>=2.7.5",
         "requests>=2.20",
     ],
     extras_require={

--- a/tests/unit/actions/test_domain.py
+++ b/tests/unit/actions/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.actions.domain import Action
 
@@ -11,8 +10,8 @@ class TestAction:
             id=1, started="2016-01-30T23:50+00:00", finished="2016-03-30T23:50+00:00"
         )
         assert action.started == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )
         assert action.finished == datetime.datetime(
-            2016, 3, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 3, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/certificates/test_domain.py
+++ b/tests/unit/certificates/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.certificates.domain import Certificate
 
@@ -14,11 +13,11 @@ class TestCertificate:
             not_valid_before="2016-01-30T23:50+00:00",
         )
         assert certificate.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )
         assert certificate.not_valid_after == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )
         assert certificate.not_valid_before == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/core/test_domain.py
+++ b/tests/unit/core/test_domain.py
@@ -1,5 +1,6 @@
+from datetime import datetime
+
 import pytest
-from dateutil.parser import isoparse
 
 from hcloud.core.domain import (
     BaseDomain,
@@ -101,7 +102,7 @@ class ActionDomain(BaseDomain, DomainIdentityMixin):
     def __init__(self, id, name="name1", started=None):
         self.id = id
         self.name = name
-        self.started = isoparse(started) if started else None
+        self.started = datetime.fromisoformat(started) if started else None
 
 
 class TestBaseDomain:
@@ -125,7 +126,7 @@ class TestBaseDomain:
                 {
                     "id": 4,
                     "name": "name-name3",
-                    "started": isoparse("2016-01-30T23:50+00:00"),
+                    "started": datetime.fromisoformat("2016-01-30T23:50+00:00"),
                 },
             ),
         ],

--- a/tests/unit/firewalls/test_domain.py
+++ b/tests/unit/firewalls/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.firewalls.domain import Firewall
 
@@ -9,5 +8,5 @@ class TestFirewall:
     def test_created_is_datetime(self):
         firewall = Firewall(id=1, created="2016-01-30T23:50+00:00")
         assert firewall.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/floating_ips/test_domain.py
+++ b/tests/unit/floating_ips/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.floating_ips.domain import FloatingIP
 
@@ -9,5 +8,5 @@ class TestFloatingIP:
     def test_created_is_datetime(self):
         floatingIP = FloatingIP(id=1, created="2016-01-30T23:50+00:00")
         assert floatingIP.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -1,8 +1,8 @@
 import datetime
+from datetime import timezone
 from unittest import mock
 
 import pytest
-from dateutil.tz import tzoffset
 
 from hcloud.actions.client import BoundAction
 from hcloud.images.client import BoundImage, ImagesClient
@@ -26,14 +26,14 @@ class TestBoundImage:
         assert bound_image.image_size == 2.3
         assert bound_image.disk_size == 10
         assert bound_image.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )
         assert bound_image.os_flavor == "ubuntu"
         assert bound_image.os_version == "16.04"
         assert bound_image.architecture == "x86"
         assert bound_image.rapid_deploy is False
         assert bound_image.deprecated == datetime.datetime(
-            2018, 2, 28, 0, 0, tzinfo=tzoffset(None, 0)
+            2018, 2, 28, 0, 0, tzinfo=timezone.utc
         )
 
         assert isinstance(bound_image.created_from, BoundServer)

--- a/tests/unit/images/test_domain.py
+++ b/tests/unit/images/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.images.domain import Image
 
@@ -9,5 +8,5 @@ class TestImage:
     def test_created_is_datetime(self):
         image = Image(id=1, created="2016-01-30T23:50+00:00")
         assert image.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/isos/test_client.py
+++ b/tests/unit/isos/test_client.py
@@ -1,8 +1,8 @@
 import datetime
+from datetime import timezone
 from unittest import mock
 
 import pytest
-from dateutil.tz import tzoffset
 
 from hcloud.isos.client import BoundIso, IsosClient
 
@@ -21,7 +21,7 @@ class TestBoundIso:
         assert bound_iso.type == "public"
         assert bound_iso.architecture == "x86"
         assert bound_iso.deprecated == datetime.datetime(
-            2018, 2, 28, 0, 0, tzinfo=tzoffset(None, 0)
+            2018, 2, 28, 0, 0, tzinfo=timezone.utc
         )
 
 

--- a/tests/unit/isos/test_domain.py
+++ b/tests/unit/isos/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.isos.domain import Iso
 
@@ -9,5 +8,5 @@ class TestIso:
     def test_deprecated_is_datetime(self):
         iso = Iso(id=1, deprecated="2016-01-30T23:50+00:00")
         assert iso.deprecated == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/load_balancers/test_domain.py
+++ b/tests/unit/load_balancers/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.load_balancers.domain import LoadBalancer
 
@@ -8,6 +7,4 @@ from hcloud.load_balancers.domain import LoadBalancer
 class TestLoadBalancers:
     def test_created_is_datetime(self):
         lb = LoadBalancer(id=1, created="2016-01-30T23:50+00:00")
-        assert lb.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
-        )
+        assert lb.created == datetime.datetime(2016, 1, 30, 23, 50, tzinfo=timezone.utc)

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -1,7 +1,7 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
-from dateutil.parser import isoparse
 
 from hcloud.actions.client import BoundAction
 from hcloud.networks.client import BoundNetwork, NetworksClient
@@ -20,7 +20,9 @@ class TestBoundNetwork:
         )
 
         assert bound_network.id == 1
-        assert bound_network.created == isoparse("2016-01-30T23:50:11+00:00")
+        assert bound_network.created == datetime.fromisoformat(
+            "2016-01-30T23:50:11+00:00"
+        )
         assert bound_network.name == "mynet"
         assert bound_network.ip_range == "10.0.0.0/16"
         assert bound_network.protection["delete"] is False

--- a/tests/unit/networks/test_domain.py
+++ b/tests/unit/networks/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.networks.domain import Network
 
@@ -9,5 +8,5 @@ class TestNetwork:
     def test_created_is_datetime(self):
         network = Network(id=1, created="2016-01-30T23:50+00:00")
         assert network.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/placement_groups/test_domain.py
+++ b/tests/unit/placement_groups/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.placement_groups.domain import PlacementGroup
 
@@ -9,5 +8,5 @@ class TestPlacementGroup:
     def test_created_is_datetime(self):
         placement_group = PlacementGroup(id=1, created="2016-01-30T23:50+00:00")
         assert placement_group.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/primary_ips/test_domain.py
+++ b/tests/unit/primary_ips/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.primary_ips.domain import PrimaryIP
 
@@ -9,5 +8,5 @@ class TestPrimaryIP:
     def test_created_is_datetime(self):
         primaryIP = PrimaryIP(id=1, created="2016-01-30T23:50+00:00")
         assert primaryIP.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/servers/test_domain.py
+++ b/tests/unit/servers/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.servers.domain import Server
 
@@ -9,5 +8,5 @@ class TestServer:
     def test_created_is_datetime(self):
         server = Server(id=1, created="2016-01-30T23:50+00:00")
         assert server.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/ssh_keys/test_domain.py
+++ b/tests/unit/ssh_keys/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.ssh_keys.domain import SSHKey
 
@@ -9,5 +8,5 @@ class TestSSHKey:
     def test_created_is_datetime(self):
         sshKey = SSHKey(id=1, created="2016-01-30T23:50+00:00")
         assert sshKey.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -1,7 +1,7 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
-from dateutil.parser import isoparse
 
 from hcloud.actions.client import BoundAction
 from hcloud.locations.client import BoundLocation
@@ -23,7 +23,9 @@ class TestBoundVolume:
         )
 
         assert bound_volume.id == 1
-        assert bound_volume.created == isoparse("2016-01-30T23:50:11+00:00")
+        assert bound_volume.created == datetime.fromisoformat(
+            "2016-01-30T23:50:11+00:00"
+        )
         assert bound_volume.name == "database-storage"
         assert isinstance(bound_volume.server, BoundServer)
         assert bound_volume.server.id == 12

--- a/tests/unit/volumes/test_domain.py
+++ b/tests/unit/volumes/test_domain.py
@@ -1,6 +1,5 @@
 import datetime
-
-from dateutil.tz import tzoffset
+from datetime import timezone
 
 from hcloud.volumes.domain import Volume
 
@@ -9,5 +8,5 @@ class TestVolume:
     def test_created_is_datetime(self):
         volume = Volume(id=1, created="2016-01-30T23:50+00:00")
         assert volume.created == datetime.datetime(
-            2016, 1, 30, 23, 50, tzinfo=tzoffset(None, 0)
+            2016, 1, 30, 23, 50, tzinfo=timezone.utc
         )


### PR DESCRIPTION
Suggested by https://github.com/ansible-collections/hetzner.hcloud/issues/217#issuecomment-1572684556

Remove the python-dateutil dependency, because the python standard library already provides the same features.

isoparse was capable of guessing and parsing different implementation of ISO 8601, but as long as the API provide the same date and time format, datetime.fromisoformat will be able to parse it.



