### PR TITLE
refactor: use relative imports within the library

### DIFF
--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -1,7 +1,7 @@
 import time
 
-from hcloud.actions.domain import Action, ActionFailedException, ActionTimeoutException
-from hcloud.core.client import BoundModelBase, ClientEntityBase
+from ..core.client import BoundModelBase, ClientEntityBase
+from .domain import Action, ActionFailedException, ActionTimeoutException
 
 
 class BoundAction(BoundModelBase):

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
-
 from .._exceptions import HCloudException
+from ..core.domain import BaseDomain
 
 
 class Action(BaseDomain):

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -1,12 +1,12 @@
-from hcloud.actions.client import BoundAction
-from hcloud.certificates.domain import (
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from .domain import (
     Certificate,
     CreateManagedCertificateResponse,
     ManagedCertificateError,
     ManagedCertificateStatus,
 )
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
 
 
 class BoundCertificate(BoundModelBase):

--- a/hcloud/certificates/domain.py
+++ b/hcloud/certificates/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class Certificate(BaseDomain, DomainIdentityMixin):

--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -1,4 +1,4 @@
-from hcloud.core.domain import add_meta_to_result
+from .domain import add_meta_to_result
 
 
 class ClientEntityBase:

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -1,7 +1,7 @@
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.datacenters.domain import Datacenter, DatacenterServerTypes
-from hcloud.locations.client import BoundLocation
-from hcloud.server_types.client import BoundServerType
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..locations.client import BoundLocation
+from ..server_types.client import BoundServerType
+from .domain import Datacenter, DatacenterServerTypes
 
 
 class BoundDatacenter(BoundModelBase):

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -1,4 +1,4 @@
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class Datacenter(BaseDomain, DomainIdentityMixin):

--- a/hcloud/deprecation/domain.py
+++ b/hcloud/deprecation/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class DeprecationInfo(BaseDomain):

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -1,7 +1,7 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.firewalls.domain import (
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from .domain import (
     CreateFirewallResponse,
     Firewall,
     FirewallResource,
@@ -31,7 +31,7 @@ class BoundFirewall(BoundModelBase):
 
         applied_to = data.get("applied_to", [])
         if applied_to:
-            from hcloud.servers.client import BoundServer
+            from ..servers.client import BoundServer
 
             ats = []
             for a in applied_to:

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class Firewall(BaseDomain):

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -1,15 +1,15 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.floating_ips.domain import CreateFloatingIPResponse, FloatingIP
-from hcloud.locations.client import BoundLocation
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from ..locations.client import BoundLocation
+from .domain import CreateFloatingIPResponse, FloatingIP
 
 
 class BoundFloatingIP(BoundModelBase):
     model = FloatingIP
 
     def __init__(self, client, data, complete=True):
-        from hcloud.servers.client import BoundServer
+        from ..servers.client import BoundServer
 
         server = data.get("server")
         if server is not None:

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class FloatingIP(BaseDomain):

--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -2,26 +2,25 @@ import time
 
 import requests
 
-from hcloud.actions.client import ActionsClient
-from hcloud.certificates.client import CertificatesClient
-from hcloud.datacenters.client import DatacentersClient
-from hcloud.firewalls.client import FirewallsClient
-from hcloud.floating_ips.client import FloatingIPsClient
-from hcloud.images.client import ImagesClient
-from hcloud.isos.client import IsosClient
-from hcloud.load_balancer_types.client import LoadBalancerTypesClient
-from hcloud.load_balancers.client import LoadBalancersClient
-from hcloud.locations.client import LocationsClient
-from hcloud.networks.client import NetworksClient
-from hcloud.placement_groups.client import PlacementGroupsClient
-from hcloud.primary_ips.client import PrimaryIPsClient
-from hcloud.server_types.client import ServerTypesClient
-from hcloud.servers.client import ServersClient
-from hcloud.ssh_keys.client import SSHKeysClient
-from hcloud.volumes.client import VolumesClient
-
 from .__version__ import VERSION
 from ._exceptions import APIException
+from .actions.client import ActionsClient
+from .certificates.client import CertificatesClient
+from .datacenters.client import DatacentersClient
+from .firewalls.client import FirewallsClient
+from .floating_ips.client import FloatingIPsClient
+from .images.client import ImagesClient
+from .isos.client import IsosClient
+from .load_balancer_types.client import LoadBalancerTypesClient
+from .load_balancers.client import LoadBalancersClient
+from .locations.client import LocationsClient
+from .networks.client import NetworksClient
+from .placement_groups.client import PlacementGroupsClient
+from .primary_ips.client import PrimaryIPsClient
+from .server_types.client import ServerTypesClient
+from .servers.client import ServersClient
+from .ssh_keys.client import SSHKeysClient
+from .volumes.client import VolumesClient
 
 
 class Client:

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -1,14 +1,14 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.images.domain import Image
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from .domain import Image
 
 
 class BoundImage(BoundModelBase):
     model = Image
 
     def __init__(self, client, data):
-        from hcloud.servers.client import BoundServer
+        from ..servers.client import BoundServer
 
         created_from = data.get("created_from")
         if created_from is not None:

--- a/hcloud/images/domain.py
+++ b/hcloud/images/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class Image(BaseDomain, DomainIdentityMixin):

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -1,7 +1,7 @@
 from warnings import warn
 
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.isos.domain import Iso
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import Iso
 
 
 class BoundIso(BoundModelBase):

--- a/hcloud/isos/domain.py
+++ b/hcloud/isos/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class Iso(BaseDomain, DomainIdentityMixin):

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -1,5 +1,5 @@
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.load_balancer_types.domain import LoadBalancerType
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import LoadBalancerType
 
 
 class BoundLoadBalancerType(BoundModelBase):

--- a/hcloud/load_balancer_types/domain.py
+++ b/hcloud/load_balancer_types/domain.py
@@ -1,4 +1,4 @@
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class LoadBalancerType(BaseDomain, DomainIdentityMixin):

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -1,9 +1,12 @@
-from hcloud.actions.client import BoundAction
-from hcloud.certificates.client import BoundCertificate
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.load_balancer_types.client import BoundLoadBalancerType
-from hcloud.load_balancers.domain import (
+from ..actions.client import BoundAction
+from ..certificates.client import BoundCertificate
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from ..load_balancer_types.client import BoundLoadBalancerType
+from ..locations.client import BoundLocation
+from ..networks.client import BoundNetwork
+from ..servers.client import BoundServer
+from .domain import (
     CreateLoadBalancerResponse,
     IPv4Address,
     IPv6Network,
@@ -19,9 +22,6 @@ from hcloud.load_balancers.domain import (
     PrivateNet,
     PublicNetwork,
 )
-from hcloud.locations.client import BoundLocation
-from hcloud.networks.client import BoundNetwork
-from hcloud.servers.client import BoundServer
 
 
 class BoundLoadBalancer(BoundModelBase):

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class LoadBalancer(BaseDomain):

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -1,5 +1,5 @@
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.locations.domain import Location
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import Location
 
 
 class BoundLocation(BoundModelBase):

--- a/hcloud/locations/domain.py
+++ b/hcloud/locations/domain.py
@@ -1,4 +1,4 @@
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class Location(BaseDomain, DomainIdentityMixin):

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -1,7 +1,7 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.networks.domain import Network, NetworkRoute, NetworkSubnet
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from .domain import Network, NetworkRoute, NetworkSubnet
 
 
 class BoundNetwork(BoundModelBase):
@@ -18,7 +18,7 @@ class BoundNetwork(BoundModelBase):
             routes = [NetworkRoute.from_dict(route) for route in routes]
             data["routes"] = routes
 
-        from hcloud.servers.client import BoundServer
+        from ..servers.client import BoundServer
 
         servers = data.get("servers", [])
         if servers is not None:

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class Network(BaseDomain):

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -1,6 +1,6 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.placement_groups.domain import CreatePlacementGroupResponse, PlacementGroup
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import CreatePlacementGroupResponse, PlacementGroup
 
 
 class BoundPlacementGroup(BoundModelBase):

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class PlacementGroup(BaseDomain):

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -1,13 +1,13 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.primary_ips.domain import CreatePrimaryIPResponse, PrimaryIP
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import CreatePrimaryIPResponse, PrimaryIP
 
 
 class BoundPrimaryIP(BoundModelBase):
     model = PrimaryIP
 
     def __init__(self, client, data, complete=True):
-        from hcloud.datacenters.client import BoundDatacenter
+        from ..datacenters.client import BoundDatacenter
 
         datacenter = data.get("datacenter", {})
         if datacenter:

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class PrimaryIP(BaseDomain):

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -1,5 +1,5 @@
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.server_types.domain import ServerType
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import ServerType
 
 
 class BoundServerType(BoundModelBase):

--- a/hcloud/server_types/domain.py
+++ b/hcloud/server_types/domain.py
@@ -1,5 +1,5 @@
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
-from hcloud.deprecation.domain import DeprecationInfo
+from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..deprecation.domain import DeprecationInfo
 
 
 class ServerType(BaseDomain, DomainIdentityMixin):

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -1,18 +1,19 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.datacenters.client import BoundDatacenter
-from hcloud.firewalls.client import BoundFirewall
-from hcloud.floating_ips.client import BoundFloatingIP
-from hcloud.images.client import BoundImage
-from hcloud.images.domain import CreateImageResponse
-from hcloud.isos.client import BoundIso
-from hcloud.networks.client import BoundNetwork  # noqa
-from hcloud.networks.domain import Network  # noqa
-from hcloud.placement_groups.client import BoundPlacementGroup
-from hcloud.primary_ips.client import BoundPrimaryIP
-from hcloud.server_types.client import BoundServerType
-from hcloud.servers.domain import (
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from ..datacenters.client import BoundDatacenter
+from ..firewalls.client import BoundFirewall
+from ..floating_ips.client import BoundFloatingIP
+from ..images.client import BoundImage
+from ..images.domain import CreateImageResponse
+from ..isos.client import BoundIso
+from ..networks.client import BoundNetwork  # noqa
+from ..networks.domain import Network  # noqa
+from ..placement_groups.client import BoundPlacementGroup
+from ..primary_ips.client import BoundPrimaryIP
+from ..server_types.client import BoundServerType
+from ..volumes.client import BoundVolume
+from .domain import (
     CreateServerResponse,
     EnableRescueResponse,
     IPv4Address,
@@ -24,7 +25,6 @@ from hcloud.servers.domain import (
     ResetPasswordResponse,
     Server,
 )
-from hcloud.volumes.client import BoundVolume
 
 
 class BoundServer(BoundModelBase):

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain
+from ..core.domain import BaseDomain
 
 
 class Server(BaseDomain):

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -1,5 +1,5 @@
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.ssh_keys.domain import SSHKey
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from .domain import SSHKey
 
 
 class BoundSSHKey(BoundModelBase):

--- a/hcloud/ssh_keys/domain.py
+++ b/hcloud/ssh_keys/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class SSHKey(BaseDomain, DomainIdentityMixin):

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -1,8 +1,8 @@
-from hcloud.actions.client import BoundAction
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import add_meta_to_result
-from hcloud.locations.client import BoundLocation
-from hcloud.volumes.domain import CreateVolumeResponse, Volume
+from ..actions.client import BoundAction
+from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core.domain import add_meta_to_result
+from ..locations.client import BoundLocation
+from .domain import CreateVolumeResponse, Volume
 
 
 class BoundVolume(BoundModelBase):
@@ -13,7 +13,7 @@ class BoundVolume(BoundModelBase):
         if location is not None:
             data["location"] = BoundLocation(client._client.locations, location)
 
-        from hcloud.servers.client import BoundServer
+        from ..servers.client import BoundServer
 
         server = data.get("server")
         if server is not None:

--- a/hcloud/volumes/domain.py
+++ b/hcloud/volumes/domain.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin
+from ..core.domain import BaseDomain, DomainIdentityMixin
 
 
 class Volume(BaseDomain, DomainIdentityMixin):


### PR DESCRIPTION
Prefer using relative imports within the library.

This also allow us to move the library into a different python path/package and still be able to use it. For example, if we vendor the package.