### PR TITLE
feat: add details to raised exceptions

### DIFF
--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -6,9 +6,7 @@ class APIException(HCloudException):
     """There was an error while performing an API Request"""
 
     def __init__(self, code, message, details):
+        super().__init__(message)
         self.code = code
         self.message = message
         self.details = details
-
-    def __str__(self):
-        return self.message

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -61,12 +61,18 @@ class ActionException(HCloudException):
     """A generic action exception"""
 
     def __init__(self, action):
+        message = self.__doc__
+        if action.error is not None and "message" in action.error:
+            message += f": {action.error['message']}"
+
+        super().__init__(message)
+        self.message = message
         self.action = action
 
 
 class ActionFailedException(ActionException):
-    """The Action you were waiting for failed"""
+    """The pending action failed"""
 
 
 class ActionTimeoutException(ActionException):
-    """The Action you were waiting for timed out"""
+    """The pending action timed out"""

--- a/tests/unit/actions/test_domain.py
+++ b/tests/unit/actions/test_domain.py
@@ -1,7 +1,14 @@
 import datetime
 from datetime import timezone
 
-from hcloud.actions.domain import Action
+import pytest
+
+from hcloud.actions.domain import (
+    Action,
+    ActionException,
+    ActionFailedException,
+    ActionTimeoutException,
+)
 
 
 class TestAction:
@@ -14,4 +21,44 @@ class TestAction:
         )
         assert action.finished == datetime.datetime(
             2016, 3, 30, 23, 50, tzinfo=timezone.utc
+        )
+
+
+def test_action_exceptions():
+    with pytest.raises(
+        ActionException,
+        match=r"The pending action failed: Server does not exist anymore",
+    ):
+        raise ActionFailedException(
+            action=Action(
+                **{
+                    "id": 1084730887,
+                    "command": "change_server_type",
+                    "status": "error",
+                    "progress": 100,
+                    "resources": [{"id": 34574042, "type": "server"}],
+                    "error": {
+                        "code": "server_does_not_exist_anymore",
+                        "message": "Server does not exist anymore",
+                    },
+                    "started": "2023-07-06T14:52:42+00:00",
+                    "finished": "2023-07-06T14:53:08+00:00",
+                }
+            )
+        )
+
+    with pytest.raises(ActionException, match=r"The pending action timed out"):
+        raise ActionTimeoutException(
+            action=Action(
+                **{
+                    "id": 1084659545,
+                    "command": "create_server",
+                    "status": "running",
+                    "progress": 50,
+                    "started": "2023-07-06T13:58:38+00:00",
+                    "finished": None,
+                    "resources": [{"id": 34572291, "type": "server"}],
+                    "error": None,
+                }
+            )
         )


### PR DESCRIPTION
Add more details to the exception message, for example, the `ActionFailedException` didn't print any message:
```
hcloud.actions.domain.ActionFailedException:
```

But will now print:
```
hcloud.actions.domain.ActionFailedException: The pending action failed: Server does not exist anymore
```

This will also provide more details for the Ansible errors.