### PR TITLE
refactor: add from __future__ import annotations imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from datetime import datetime

--- a/examples/create_server.py
+++ b/examples/create_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hcloud import Client
 from hcloud.images.domain import Image
 from hcloud.server_types.domain import ServerType

--- a/examples/list_servers.py
+++ b/examples/list_servers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hcloud import Client
 
 client = Client(

--- a/examples/usage_oop.py
+++ b/examples/usage_oop.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hcloud import Client
 from hcloud.images.domain import Image
 from hcloud.server_types.domain import ServerType

--- a/examples/usage_procedurale.py
+++ b/examples/usage_procedurale.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hcloud import Client
 from hcloud.images.domain import Image
 from hcloud.server_types.domain import ServerType

--- a/hcloud/__init__.py
+++ b/hcloud/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from ._client import Client  # noqa
 from ._exceptions import APIException, HCloudException  # noqa

--- a/hcloud/__version__.py
+++ b/hcloud/__version__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 VERSION = "1.26.0"  # x-release-please-version

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import time
-from typing import Optional, Union
 
 import requests
 
@@ -35,8 +36,8 @@ class Client:
         self,
         token: str,
         api_endpoint: str = "https://api.hetzner.cloud/v1",
-        application_name: Optional[str] = None,
-        application_version: Optional[str] = None,
+        application_name: str | None = None,
+        application_version: str | None = None,
         poll_interval: int = 1,
     ):
         """Create an new Client instance
@@ -186,7 +187,7 @@ class Client:
         url: str,
         tries: int = 1,
         **kwargs,
-    ) -> Union[bytes, dict]:
+    ) -> bytes | dict:
         """Perform a request to the Hetzner Cloud API, wrapper around requests.request
 
         :param method: HTTP Method to perform the Request

--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class HCloudException(Exception):
     """There was an error while using the hcloud library"""
 

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from ..core.client import BoundModelBase, ClientEntityBase

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from .._exceptions import HCloudException

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/certificates/domain.py
+++ b/hcloud/certificates/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain, DomainIdentityMixin

--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .domain import add_meta_to_result
 
 
@@ -34,7 +36,7 @@ class ClientEntityBase:
         list_function,  # type: function
         results_list_attribute_name,  # type: str
         *args,
-        **kwargs
+        **kwargs,
     ):
         # type (...) -> List[BoundModelBase]
 

--- a/hcloud/core/domain.py
+++ b/hcloud/core/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple
 
 

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..locations.client import BoundLocation
 from ..server_types.client import BoundServerType

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.domain import BaseDomain, DomainIdentityMixin
 
 

--- a/hcloud/deprecation/domain.py
+++ b/hcloud/deprecation/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/hcloud.py
+++ b/hcloud/hcloud.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 
 warnings.warn(

--- a/hcloud/helpers/labels.py
+++ b/hcloud/helpers/labels.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import re
-from typing import Dict
 
 
 class LabelValidator:
@@ -11,7 +12,7 @@ class LabelValidator:
     )
 
     @staticmethod
-    def validate(labels: Dict[str, str]) -> bool:
+    def validate(labels: dict[str, str]) -> bool:
         """Validates Labels. If you want to know which key/value pair of the dict is not correctly formatted
         use :func:`~hcloud.helpers.labels.validate_verbose`.
 
@@ -25,7 +26,7 @@ class LabelValidator:
         return True
 
     @staticmethod
-    def validate_verbose(labels: Dict[str, str]) -> (bool, str):
+    def validate_verbose(labels: dict[str, str]) -> tuple(bool, str):
         """Validates Labels and returns the corresponding error message if something is wrong. Returns True, <empty string>
         if everything is fine.
 

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/images/domain.py
+++ b/hcloud/images/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain, DomainIdentityMixin

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from warnings import warn
 
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin

--- a/hcloud/isos/domain.py
+++ b/hcloud/isos/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain, DomainIdentityMixin

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from .domain import LoadBalancerType
 

--- a/hcloud/load_balancer_types/domain.py
+++ b/hcloud/load_balancer_types/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.domain import BaseDomain, DomainIdentityMixin
 
 

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..certificates.client import BoundCertificate
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from .domain import Location
 

--- a/hcloud/locations/domain.py
+++ b/hcloud/locations/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.domain import BaseDomain, DomainIdentityMixin
 
 

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from .domain import CreatePlacementGroupResponse, PlacementGroup

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from .domain import CreatePrimaryIPResponse, PrimaryIP

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from .domain import ServerType
 

--- a/hcloud/server_types/domain.py
+++ b/hcloud/server_types/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.domain import BaseDomain, DomainIdentityMixin
 from ..deprecation.domain import DeprecationInfo
 

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from .domain import SSHKey
 

--- a/hcloud/ssh_keys/domain.py
+++ b/hcloud/ssh_keys/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain, DomainIdentityMixin

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..actions.client import BoundAction
 from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
 from ..core.domain import add_meta_to_result

--- a/hcloud/volumes/domain.py
+++ b/hcloud/volumes/domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dateutil.parser import isoparse
 
 from ..core.domain import BaseDomain, DomainIdentityMixin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.isort]
 profile = "black"
 combine_as_imports = true
+add_imports = ["from __future__ import annotations"]
 
 [tool.coverage.run]
 source = ["hcloud"]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import find_packages, setup
 
 with open("README.rst") as readme_file:

--- a/tests/unit/actions/conftest.py
+++ b/tests/unit/actions/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/actions/test_domain.py
+++ b/tests/unit/actions/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/certificates/conftest.py
+++ b/tests/unit/certificates/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/certificates/test_domain.py
+++ b/tests/unit/certificates/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/core/test_domain.py
+++ b/tests/unit/core/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from dateutil.parser import isoparse
 

--- a/tests/unit/datacenters/conftest.py
+++ b/tests/unit/datacenters/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/datacenters/test_client.py
+++ b/tests/unit/datacenters/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock  # noqa: F401
 
 import pytest  # noqa: F401

--- a/tests/unit/firewalls/conftest.py
+++ b/tests/unit/firewalls/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/firewalls/test_domain.py
+++ b/tests/unit/firewalls/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/floating_ips/conftest.py
+++ b/tests/unit/floating_ips/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/floating_ips/test_domain.py
+++ b/tests/unit/floating_ips/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/helpers/test_labels.py
+++ b/tests/unit/helpers/test_labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from hcloud.helpers.labels import LabelValidator

--- a/tests/unit/images/conftest.py
+++ b/tests/unit/images/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 from unittest import mock

--- a/tests/unit/images/test_domain.py
+++ b/tests/unit/images/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/isos/conftest.py
+++ b/tests/unit/isos/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/isos/test_client.py
+++ b/tests/unit/isos/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 from unittest import mock

--- a/tests/unit/isos/test_domain.py
+++ b/tests/unit/isos/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/load_balancer_types/conftest.py
+++ b/tests/unit/load_balancer_types/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/load_balancer_types/test_client.py
+++ b/tests/unit/load_balancer_types/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/load_balancers/conftest.py
+++ b/tests/unit/load_balancers/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/load_balancers/test_domain.py
+++ b/tests/unit/load_balancers/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/locations/conftest.py
+++ b/tests/unit/locations/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/locations/test_client.py
+++ b/tests/unit/locations/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock  # noqa: F401
 
 import pytest  # noqa: F401

--- a/tests/unit/networks/conftest.py
+++ b/tests/unit/networks/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/networks/test_domain.py
+++ b/tests/unit/networks/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/placement_groups/conftest.py
+++ b/tests/unit/placement_groups/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/placement_groups/test_client.py
+++ b/tests/unit/placement_groups/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/placement_groups/test_domain.py
+++ b/tests/unit/placement_groups/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/primary_ips/conftest.py
+++ b/tests/unit/primary_ips/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/primary_ips/test_domain.py
+++ b/tests/unit/primary_ips/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/server_types/conftest.py
+++ b/tests/unit/server_types/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/server_types/test_client.py
+++ b/tests/unit/server_types/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from unittest import mock
 

--- a/tests/unit/servers/conftest.py
+++ b/tests/unit/servers/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/servers/test_domain.py
+++ b/tests/unit/servers/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/ssh_keys/conftest.py
+++ b/tests/unit/ssh_keys/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/ssh_keys/test_client.py
+++ b/tests/unit/ssh_keys/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/ssh_keys/test_domain.py
+++ b/tests/unit/ssh_keys/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from unittest.mock import MagicMock
 

--- a/tests/unit/test_hcloud.py
+++ b/tests/unit/test_hcloud.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/volumes/conftest.py
+++ b/tests/unit/volumes/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/volumes/test_domain.py
+++ b/tests/unit/volumes/test_domain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
 


### PR DESCRIPTION
This is a preparation work to simplify adding typing definition to this library.

See https://peps.python.org/pep-0563/#rationale-and-goals to better understand how this can help to introduce typings to the library.