### PR TITLE
feat: implement resource actions clients

### DIFF
--- a/docs/api.clients.actions.rst
+++ b/docs/api.clients.actions.rst
@@ -1,9 +1,12 @@
 ActionsClient
 ==================
 
+.. autoclass:: hcloud.actions.client.ResourceActionsClient
+    :members:
 
 .. autoclass:: hcloud.actions.client.ActionsClient
     :members:
+    :inherited-members:
 
 .. autoclass:: hcloud.actions.client.BoundAction
     :members:

--- a/hcloud/actions/__init__.py
+++ b/hcloud/actions/__init__.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from .client import ActionsClient, ActionsPageResult, BoundAction  # noqa: F401
+from .client import (  # noqa: F401
+    ActionsClient,
+    ActionsPageResult,
+    BoundAction,
+    ResourceActionsClient,
+)
 from .domain import (  # noqa: F401
     Action,
     ActionException,

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, Meta
@@ -118,3 +119,33 @@ class ResourceActionsClient(ClientEntityBase):
 class ActionsClient(ResourceActionsClient):
     def __init__(self, client: Client):
         super().__init__(client, None)
+
+    def get_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
+        warnings.warn(
+            "The 'client.actions.get_list' method is deprecated, please use the "
+            "'client.<resource>.actions.get_list' method instead (e.g. "
+            "'client.certificates.actions.get_list').",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().get_list(status=status, sort=sort, page=page, per_page=per_page)
+
+    def get_all(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
+        warnings.warn(
+            "The 'client.actions.get_all' method is deprecated, please use the "
+            "'client.<resource>.actions.get_all' method instead (e.g. "
+            "'client.certificates.actions.get_all').",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().get_all(status=status, sort=sort)

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -131,6 +131,8 @@ class ActionsClient(ResourceActionsClient):
         .. deprecated:: 1.28
         Use :func:`client.<resource>.actions.get_list` instead,
         e.g. using :attr:`hcloud.certificates.client.CertificatesClient.actions`.
+
+        `Starting 1 October 2023, it will no longer be available. <https://docs.hetzner.cloud/changelog#2023-07-20-actions-list-endpoint-is-deprecated>`_
         """
         warnings.warn(
             "The 'client.actions.get_list' method is deprecated, please use the "
@@ -150,6 +152,8 @@ class ActionsClient(ResourceActionsClient):
         .. deprecated:: 1.28
         Use :func:`client.<resource>.actions.get_all` instead,
         e.g. using :attr:`hcloud.certificates.client.CertificatesClient.actions`.
+
+        `Starting 1 October 2023, it will no longer be available. <https://docs.hetzner.cloud/changelog#2023-07-20-actions-list-endpoint-is-deprecated>`_
         """
         warnings.warn(
             "The 'client.actions.get_all' method is deprecated, please use the "

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -127,6 +127,11 @@ class ActionsClient(ResourceActionsClient):
         page: int | None = None,
         per_page: int | None = None,
     ) -> ActionsPageResult:
+        """
+        .. deprecated:: 1.28
+        Use :func:`client.<resource>.actions.get_list` instead,
+        e.g. using :attr:`hcloud.certificates.client.CertificatesClient.actions`.
+        """
         warnings.warn(
             "The 'client.actions.get_list' method is deprecated, please use the "
             "'client.<resource>.actions.get_list' method instead (e.g. "
@@ -141,6 +146,11 @@ class ActionsClient(ResourceActionsClient):
         status: list[str] | None = None,
         sort: list[str] | None = None,
     ) -> list[BoundAction]:
+        """
+        .. deprecated:: 1.28
+        Use :func:`client.<resource>.actions.get_all` instead,
+        e.g. using :attr:`hcloud.certificates.client.CertificatesClient.actions`.
+        """
         warnings.warn(
             "The 'client.actions.get_all' method is deprecated, please use the "
             "'client.<resource>.actions.get_all' method instead (e.g. "

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -107,9 +107,9 @@ class CertificatesClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Certificates actions client
+    """Certificates scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import (
     Certificate,
@@ -105,6 +105,16 @@ class CertificatesPageResult(NamedTuple):
 
 class CertificatesClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Certificates actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/certificates")
 
     def get_by_id(self, id: int) -> BoundCertificate:
         """Get a specific certificate by its ID.

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -162,9 +162,9 @@ class FirewallsClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Firewalls actions client
+    """Firewalls scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import (
     CreateFirewallResponse,
@@ -160,6 +160,16 @@ class FirewallsPageResult(NamedTuple):
 
 class FirewallsClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Firewalls actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/firewalls")
 
     def get_actions_list(
         self,

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from ..locations import BoundLocation
 from .domain import CreateFloatingIPResponse, FloatingIP
@@ -140,6 +140,16 @@ class FloatingIPsPageResult(NamedTuple):
 
 class FloatingIPsClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Floating IPs actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/floating_ips")
 
     def get_actions_list(
         self,

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -142,9 +142,9 @@ class FloatingIPsClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Floating IPs actions client
+    """Floating IPs scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import Image
 
@@ -112,6 +112,16 @@ class ImagesPageResult(NamedTuple):
 
 class ImagesClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Images actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/images")
 
     def get_actions_list(
         self,

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -114,9 +114,9 @@ class ImagesClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Images actions client
+    """Images scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -332,9 +332,9 @@ class LoadBalancersClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Load Balancers actions client
+    """Load Balancers scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..certificates import BoundCertificate
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from ..load_balancer_types import BoundLoadBalancerType
@@ -330,6 +330,16 @@ class LoadBalancersPageResult(NamedTuple):
 
 class LoadBalancersClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Load Balancers actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/load_balancers")
 
     def get_by_id(self, id: int) -> BoundLoadBalancer:
         """Get a specific Load Balancer

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import Network, NetworkRoute, NetworkSubnet
 
@@ -167,6 +167,16 @@ class NetworksPageResult(NamedTuple):
 
 class NetworksClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Networks actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/networks")
 
     def get_by_id(self, id: int) -> BoundNetwork:
         """Get a specific network

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -169,9 +169,9 @@ class NetworksClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Networks actions client
+    """Networks scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -100,9 +100,9 @@ class PrimaryIPsClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Primary IPs actions client
+    """Primary IPs scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import BoundAction
+from ..actions import BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import CreatePrimaryIPResponse, PrimaryIP
 
@@ -98,6 +98,16 @@ class PrimaryIPsPageResult(NamedTuple):
 
 class PrimaryIPsClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Primary IPs actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/primary_ips")
 
     def get_by_id(self, id: int) -> BoundPrimaryIP:
         """Returns a specific Primary IP object.

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from ..datacenters import BoundDatacenter
 from ..firewalls import BoundFirewall
@@ -447,6 +447,16 @@ class ServersPageResult(NamedTuple):
 
 class ServersClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Servers actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/servers")
 
     def get_by_id(self, id: int) -> BoundServer:
         """Get a specific server

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -449,9 +449,9 @@ class ServersClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Servers actions client
+    """Servers scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -138,9 +138,9 @@ class VolumesClient(ClientEntityBase):
     _client: Client
 
     actions: ResourceActionsClient
-    """Volumes actions client
+    """Volumes scoped actions client
 
-    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    :type: :class:`ResourceActionsClient <hcloud.actions.client.ResourceActionsClient>`
     """
 
     def __init__(self, client: Client):

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from ..actions import ActionsPageResult, BoundAction
+from ..actions import ActionsPageResult, BoundAction, ResourceActionsClient
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from ..locations import BoundLocation
 from .domain import CreateVolumeResponse, Volume
@@ -136,6 +136,16 @@ class VolumesPageResult(NamedTuple):
 
 class VolumesClient(ClientEntityBase):
     _client: Client
+
+    actions: ResourceActionsClient
+    """Volumes actions client
+
+    :type: :class:`ResourceActionsClient <hcloud.actions.ResourceActionsClient>`
+    """
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.actions = ResourceActionsClient(client, "/volumes")
 
     def get_by_id(self, id: int) -> BoundVolume:
         """Get a specific volume by its id

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -30,6 +30,8 @@ class TestBoundAction:
     ):
         mocked_requests.request.side_effect = [running_action, successfully_action]
         bound_running_action.wait_until_finished()
+        mocked_requests.request.assert_called_with(url="/actions/2", method="GET")
+
         assert bound_running_action.status == "success"
         assert mocked_requests.request.call_count == 2
 

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -288,3 +288,53 @@ class TestCertificatesClient:
 
         assert action.id == 14
         assert action.command == "issue_certificate"
+
+    def test_actions_get_by_id(self, certificates_client, response_get_actions):
+        certificates_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = certificates_client.actions.get_by_id(13)
+
+        certificates_client._client.request.assert_called_with(
+            url="/certificates/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == certificates_client._client.actions
+        assert action.id == 13
+        assert action.command == "change_protection"
+
+    def test_actions_get_list(self, certificates_client, response_get_actions):
+        certificates_client._client.request.return_value = response_get_actions
+        result = certificates_client.actions.get_list()
+
+        certificates_client._client.request.assert_called_with(
+            url="/certificates/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == certificates_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "change_protection"
+
+    def test_actions_get_all(self, certificates_client, response_get_actions):
+        certificates_client._client.request.return_value = response_get_actions
+        actions = certificates_client.actions.get_all()
+
+        certificates_client._client.request.assert_called_with(
+            url="/certificates/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == certificates_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "change_protection"

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -33,6 +33,7 @@ class TestBoundCertificate:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "change_protection"
 
@@ -48,6 +49,7 @@ class TestBoundCertificate:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "change_protection"
 

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -462,3 +462,53 @@ class TestFirewallsClient:
 
         assert actions[0].id == 13
         assert actions[0].progress == 100
+
+    def test_actions_get_by_id(self, firewalls_client, response_get_actions):
+        firewalls_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = firewalls_client.actions.get_by_id(13)
+
+        firewalls_client._client.request.assert_called_with(
+            url="/firewalls/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == firewalls_client._client.actions
+        assert action.id == 13
+        assert action.command == "set_firewall_rules"
+
+    def test_actions_get_list(self, firewalls_client, response_get_actions):
+        firewalls_client._client.request.return_value = response_get_actions
+        result = firewalls_client.actions.get_list()
+
+        firewalls_client._client.request.assert_called_with(
+            url="/firewalls/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == firewalls_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "set_firewall_rules"
+
+    def test_actions_get_all(self, firewalls_client, response_get_actions):
+        firewalls_client._client.request.return_value = response_get_actions
+        actions = firewalls_client.actions.get_all()
+
+        firewalls_client._client.request.assert_called_with(
+            url="/firewalls/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == firewalls_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "set_firewall_rules"

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -88,6 +88,7 @@ class TestBoundFirewall:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "set_firewall_rules"
 
@@ -106,6 +107,7 @@ class TestBoundFirewall:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "set_firewall_rules"
 

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -52,6 +52,7 @@ class TestBoundFloatingIP:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "assign_floating_ip"
 

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -392,3 +392,53 @@ class TestFloatingIPsClient:
         )
         assert action.id == 1
         assert action.progress == 0
+
+    def test_actions_get_by_id(self, floating_ips_client, response_get_actions):
+        floating_ips_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = floating_ips_client.actions.get_by_id(13)
+
+        floating_ips_client._client.request.assert_called_with(
+            url="/floating_ips/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == floating_ips_client._client.actions
+        assert action.id == 13
+        assert action.command == "assign_floating_ip"
+
+    def test_actions_get_list(self, floating_ips_client, response_get_actions):
+        floating_ips_client._client.request.return_value = response_get_actions
+        result = floating_ips_client.actions.get_list()
+
+        floating_ips_client._client.request.assert_called_with(
+            url="/floating_ips/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == floating_ips_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "assign_floating_ip"
+
+    def test_actions_get_all(self, floating_ips_client, response_get_actions):
+        floating_ips_client._client.request.return_value = response_get_actions
+        actions = floating_ips_client.actions.get_all()
+
+        floating_ips_client._client.request.assert_called_with(
+            url="/floating_ips/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == floating_ips_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "assign_floating_ip"

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -63,6 +63,7 @@ class TestBoundImage:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "change_protection"
 
@@ -81,6 +82,7 @@ class TestBoundImage:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "change_protection"
 

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -310,3 +310,53 @@ class TestImagesClient:
         )
 
         assert delete_success is True
+
+    def test_actions_get_by_id(self, images_client, response_get_actions):
+        images_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = images_client.actions.get_by_id(13)
+
+        images_client._client.request.assert_called_with(
+            url="/images/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == images_client._client.actions
+        assert action.id == 13
+        assert action.command == "change_protection"
+
+    def test_actions_get_list(self, images_client, response_get_actions):
+        images_client._client.request.return_value = response_get_actions
+        result = images_client.actions.get_list()
+
+        images_client._client.request.assert_called_with(
+            url="/images/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == images_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "change_protection"
+
+    def test_actions_get_all(self, images_client, response_get_actions):
+        images_client._client.request.return_value = response_get_actions
+        actions = images_client.actions.get_all()
+
+        images_client._client.request.assert_called_with(
+            url="/images/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == images_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "change_protection"

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -518,3 +518,53 @@ class TestLoadBalancerslient:
 
         assert action.id == 1
         assert action.progress == 0
+
+    def test_actions_get_by_id(self, load_balancers_client, response_get_actions):
+        load_balancers_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = load_balancers_client.actions.get_by_id(13)
+
+        load_balancers_client._client.request.assert_called_with(
+            url="/load_balancers/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == load_balancers_client._client.actions
+        assert action.id == 13
+        assert action.command == "change_protection"
+
+    def test_actions_get_list(self, load_balancers_client, response_get_actions):
+        load_balancers_client._client.request.return_value = response_get_actions
+        result = load_balancers_client.actions.get_list()
+
+        load_balancers_client._client.request.assert_called_with(
+            url="/load_balancers/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == load_balancers_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "change_protection"
+
+    def test_actions_get_all(self, load_balancers_client, response_get_actions):
+        load_balancers_client._client.request.return_value = response_get_actions
+        actions = load_balancers_client.actions.get_all()
+
+        load_balancers_client._client.request.assert_called_with(
+            url="/load_balancers/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == load_balancers_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "change_protection"

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -50,6 +50,7 @@ class TestBoundLoadBalancer:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "change_protection"
 
@@ -68,6 +69,7 @@ class TestBoundLoadBalancer:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "change_protection"
 

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -60,6 +60,7 @@ class TestBoundNetwork:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "add_subnet"
 

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -586,3 +586,53 @@ class TestNetworksClient:
 
         assert action.id == 1
         assert action.progress == 0
+
+    def test_actions_get_by_id(self, networks_client, response_get_actions):
+        networks_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = networks_client.actions.get_by_id(13)
+
+        networks_client._client.request.assert_called_with(
+            url="/networks/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == networks_client._client.actions
+        assert action.id == 13
+        assert action.command == "add_subnet"
+
+    def test_actions_get_list(self, networks_client, response_get_actions):
+        networks_client._client.request.return_value = response_get_actions
+        result = networks_client.actions.get_list()
+
+        networks_client._client.request.assert_called_with(
+            url="/networks/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == networks_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "add_subnet"
+
+    def test_actions_get_all(self, networks_client, response_get_actions):
+        networks_client._client.request.return_value = response_get_actions
+        actions = networks_client.actions.get_all()
+
+        networks_client._client.request.assert_called_with(
+            url="/networks/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == networks_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "add_subnet"

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -1226,3 +1226,53 @@ class TestServersClient:
         assert action.id == 1
         assert action.progress == 0
         assert action.command == "change_alias_ips"
+
+    def test_actions_get_by_id(self, servers_client, response_get_actions):
+        servers_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = servers_client.actions.get_by_id(13)
+
+        servers_client._client.request.assert_called_with(
+            url="/servers/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == servers_client._client.actions
+        assert action.id == 13
+        assert action.command == "start_server"
+
+    def test_actions_get_list(self, servers_client, response_get_actions):
+        servers_client._client.request.return_value = response_get_actions
+        result = servers_client.actions.get_list()
+
+        servers_client._client.request.assert_called_with(
+            url="/servers/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == servers_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "start_server"
+
+    def test_actions_get_all(self, servers_client, response_get_actions):
+        servers_client._client.request.return_value = response_get_actions
+        actions = servers_client.actions.get_all()
+
+        servers_client._client.request.assert_called_with(
+            url="/servers/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == servers_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "start_server"

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -147,6 +147,7 @@ class TestBoundServer:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "start_server"
 
@@ -167,6 +168,7 @@ class TestBoundServer:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "start_server"
 
@@ -604,10 +606,16 @@ class TestServersClient:
         )
 
         bound_server = response.server
+        bound_action = response.action
 
         assert bound_server._client is servers_client
         assert bound_server.id == 1
         assert bound_server.name == "my-server"
+
+        assert isinstance(bound_action, BoundAction)
+        assert bound_action._client == servers_client._client.actions
+        assert bound_action.id == 1
+        assert bound_action.command == "create_server"
 
     def test_create_with_location(self, servers_client, response_create_simple_server):
         servers_client._client.request.return_value = response_create_simple_server

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -385,3 +385,53 @@ class TestVolumesClient:
         )
         assert action.id == 1
         assert action.progress == 0
+
+    def test_actions_get_by_id(self, volumes_client, response_get_actions):
+        volumes_client._client.request.return_value = {
+            "action": response_get_actions["actions"][0]
+        }
+        action = volumes_client.actions.get_by_id(13)
+
+        volumes_client._client.request.assert_called_with(
+            url="/volumes/actions/13", method="GET"
+        )
+
+        assert isinstance(action, BoundAction)
+        assert action._client == volumes_client._client.actions
+        assert action.id == 13
+        assert action.command == "attach_volume"
+
+    def test_actions_get_list(self, volumes_client, response_get_actions):
+        volumes_client._client.request.return_value = response_get_actions
+        result = volumes_client.actions.get_list()
+
+        volumes_client._client.request.assert_called_with(
+            url="/volumes/actions",
+            method="GET",
+            params={},
+        )
+
+        actions = result.actions
+        assert result.meta is None
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == volumes_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "attach_volume"
+
+    def test_actions_get_all(self, volumes_client, response_get_actions):
+        volumes_client._client.request.return_value = response_get_actions
+        actions = volumes_client.actions.get_all()
+
+        volumes_client._client.request.assert_called_with(
+            url="/volumes/actions",
+            method="GET",
+            params={"page": 1, "per_page": 50},
+        )
+
+        assert len(actions) == 1
+        assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == volumes_client._client.actions
+        assert actions[0].id == 13
+        assert actions[0].command == "attach_volume"

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -52,6 +52,7 @@ class TestBoundVolume:
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
+        assert actions[0]._client == hetzner_client.actions
         assert actions[0].id == 13
         assert actions[0].command == "attach_volume"
 


### PR DESCRIPTION
This implements the new per resources actions endpoints.

Related to https://docs.hetzner.cloud/changelog#2023-06-29-resource-action-endpoints

```py
# Existing API
client.actions.get_by_id() # /actions/{id}
client.<resource>.get_actions_all() # /<resource>/{resource_id}/actions
client.<resource>.get_actions_list() # /<resource>/{resource_id}/actions

# New API
client.<resource>.actions.get_all() # /<resource>/actions 
client.<resource>.actions.get_list() # /<resource>/actions
client.<resource>.actions.get_by_id() # /<resource>/actions/{id}

# Not planned
client.<resource>.get_action_by_id() # /<resource>/{resource_id}/actions/{id}

# Deprecated
client.actions.get_all() # /actions
client.actions.get_list() # /actions
```

One exception is the primary IPs client, it doesn't include calls to `/<resource>/{resource_id}/actions` or `/<resource>/{resource_id}/actions/{id}`: https://docs.hetzner.cloud/#primary-ip-actions