### PR TITLE
refactor: inline _get_all

### DIFF
--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -12,20 +12,15 @@ class ClientEntityBase:
         """
         self._client = client
 
-    def _get_all(
-        self,
-        list_function,  # type: function
-        *args,
-        **kwargs,
-    ):
-        # type (...) -> List[BoundModelBase]
+    def get_all(self, *args, **kwargs):
+        # type: (...) -> List[BoundModelBase]
         results = []
 
         page = 1
         while page:
             # The *PageResult tuples MUST have the following structure
             # `(result: List[Bound*], meta: Meta)`
-            result, meta = list_function(
+            result, meta = self.get_list(
                 page=page, per_page=self.max_per_page, *args, **kwargs
             )
             if result:
@@ -42,10 +37,6 @@ class ClientEntityBase:
                 page = None
 
         return results
-
-    def get_all(self, *args, **kwargs):
-        # type: (...) -> List[BoundModelBase]
-        return self._get_all(self.get_list, *args, **kwargs)
 
     def get_actions(self, *args, **kwargs):
         # type: (...) -> List[BoundModelBase]


### PR DESCRIPTION
`ClientEntityBase._get_all` was only called from `ClientEntityBase.get_all` and `get_all` did nothing besides calling `_get_all`.

Related to https://github.com/hetznercloud/hcloud-python/pull/251#discussion_r1270785152