### PR TITLE
refactor: convert type comments to type hints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,19 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: make venv
+
+      - name: Run lint
+        run: make lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,15 @@ include:
 stages:
   - test
 
+lint:
+  stage: test
+
+  image: python:3.11-alpine
+  before_script:
+    - make venv
+  script:
+    - make lint
+
 test:
   stage: test
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ venv:
 	python3 -m venv venv
 	venv/bin/pip install -e .[docs,test]
 
+lint: venv
+	venv/bin/mypy hcloud
+
 test: venv
 	venv/bin/pytest -v
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Build the documentation and open it in your browser:
 make docs
 ```
 
+Lint the code:
+
+```sh
+make lint
+```
+
 Run tests using the current `python3` version:
 
 ```sh

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -187,7 +187,7 @@ class Client:
         url: str,
         tries: int = 1,
         **kwargs,
-    ) -> bytes | dict:
+    ) -> dict:
         """Perform a request to the Hetzner Cloud API, wrapper around requests.request
 
         :param method: HTTP Method to perform the Request
@@ -211,6 +211,7 @@ class Client:
 
         if not response.ok:
             if content:
+                assert isinstance(content, dict)
                 if content["error"]["code"] == "rate_limit_exceeded" and tries < 5:
                     time.sleep(tries * self._retry_wait_time)
                     tries = tries + 1
@@ -220,4 +221,5 @@ class Client:
             else:
                 self._raise_exception_from_response(response)
 
-        return content
+        # TODO: return an empty dict instead of an empty string when content == "".
+        return content  # type: ignore[return-value]

--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 class HCloudException(Exception):
     """There was an error while using the hcloud library"""
@@ -8,7 +10,7 @@ class HCloudException(Exception):
 class APIException(HCloudException):
     """There was an error while performing an API Request"""
 
-    def __init__(self, code, message, details):
+    def __init__(self, code: int | str, message: str, details: Any):
         super().__init__(message)
         self.code = code
         self.message = message

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -89,7 +89,9 @@ class ActionsClient(ClientEntityBase):
         return ActionsPageResult(actions, Meta.parse_meta(response))
 
     def get_all(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Get all actions of the account
 

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import Action, ActionFailedException, ActionTimeoutException
@@ -15,7 +15,7 @@ class BoundAction(BoundModelBase):
 
     model = Action
 
-    def wait_until_finished(self, max_retries=100):
+    def wait_until_finished(self, max_retries: int = 100) -> None:
         """Wait until the specific action has status="finished" (set Client.poll_interval to specify a delay between checks)
 
         :param max_retries: int
@@ -72,7 +72,7 @@ class ActionsClient(ClientEntityBase):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if status is not None:
             params["status"] = status
         if sort is not None:

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -43,8 +43,7 @@ class ActionsPageResult(NamedTuple):
 class ActionsClient(ClientEntityBase):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundAction
+    def get_by_id(self, id: int) -> BoundAction:
         """Get a specific action by its ID.
 
         :param id: int
@@ -56,12 +55,11 @@ class ActionsClient(ClientEntityBase):
 
     def get_list(
         self,
-        status=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundAction]]
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Get a list of actions from this account
 
         :param status: List[str] (optional)
@@ -90,8 +88,9 @@ class ActionsClient(ClientEntityBase):
         ]
         return ActionsPageResult(actions, Meta.parse_meta(response))
 
-    def get_all(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_all(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Get all actions of the account
 
         :param status: List[str] (optional)

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from .._exceptions import HCloudException
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from .client import BoundAction
 
 
 class Action(BaseDomain):
@@ -39,14 +44,14 @@ class Action(BaseDomain):
 
     def __init__(
         self,
-        id,
-        command=None,
-        status=None,
-        progress=None,
-        started=None,
-        finished=None,
-        resources=None,
-        error=None,
+        id: int,
+        command: str | None = None,
+        status: str | None = None,
+        progress: int | None = None,
+        started: str | None = None,
+        finished: str | None = None,
+        resources: list[dict] | None = None,
+        error: dict | None = None,
     ):
         self.id = id
         self.command = command
@@ -62,7 +67,8 @@ class Action(BaseDomain):
 class ActionException(HCloudException):
     """A generic action exception"""
 
-    def __init__(self, action):
+    def __init__(self, action: Action | BoundAction):
+        assert self.__doc__ is not None
         message = self.__doc__
         if action.error is not None and "message" in action.error:
             message += f": {action.error['message']}"

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -20,7 +20,7 @@ class BoundCertificate(BoundModelBase):
 
     model = Certificate
 
-    def __init__(self, client, data, complete=True):
+    def __init__(self, client: CertificatesClient, data: dict, complete: bool = True):
         status = data.get("status")
         if status is not None:
             error_data = status.get("error")
@@ -134,7 +134,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
 
@@ -173,7 +173,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector)
 
-    def get_by_name(self, name: str) -> BoundCertificate:
+    def get_by_name(self, name: str) -> BoundCertificate | None:
         """Get certificate by name
 
         :param name: str
@@ -201,7 +201,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>`
         """
-        data = {
+        data: dict[str, Any] = {
             "name": name,
             "certificate": certificate,
             "private_key": private_key,
@@ -228,7 +228,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>`
         """
-        data = {
+        data: dict[str, Any] = {
             "name": name,
             "type": Certificate.TYPE_MANAGED,
             "domain_names": domain_names,
@@ -243,7 +243,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        certificate: Certificate,
+        certificate: Certificate | BoundCertificate,
         name: str | None = None,
         labels: dict[str, str] | None = None,
     ) -> BoundCertificate:
@@ -256,7 +256,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if name is not None:
             data["name"] = name
         if labels is not None:
@@ -268,7 +268,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundCertificate(self, response["certificate"])
 
-    def delete(self, certificate: Certificate) -> bool:
+    def delete(self, certificate: Certificate | BoundCertificate) -> bool:
         self._client.request(
             url=f"/certificates/{certificate.id}",
             method="DELETE",
@@ -283,7 +283,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        certificate: Certificate,
+        certificate: Certificate | BoundCertificate,
         status: list[str] | None = None,
         sort: list[str] | None = None,
         page: int | None = None,
@@ -302,7 +302,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if status is not None:
             params["status"] = status
         if sort is not None:
@@ -327,7 +327,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        certificate: Certificate,
+        certificate: Certificate | BoundCertificate,
         status: list[str] | None = None,
         sort: list[str] | None = None,
     ) -> list[BoundAction]:
@@ -342,7 +342,10 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(certificate, status=status, sort=sort)
 
-    def retry_issuance(self, certificate: Certificate) -> BoundAction:
+    def retry_issuance(
+        self,
+        certificate: Certificate | BoundCertificate,
+    ) -> BoundAction:
         """Returns all action objects for a Certificate.
 
         :param certificate: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>` or :class:`Certificate <hcloud.certificates.domain.Certificate>`

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -56,7 +56,9 @@ class BoundCertificate(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a Certificate.
 
@@ -69,7 +71,9 @@ class BoundCertificate(BoundModelBase):
         return self._client.get_actions(self, status, sort)
 
     def update(
-        self, name: str | None = None, labels: dict[str, str] | None = None
+        self,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> BoundCertificate:
         """Updates an certificate. You can update an certificate name and the certificate labels.
 
@@ -155,7 +159,9 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         return CertificatesPageResult(certificates, Meta.parse_meta(response))
 
     def get_all(
-        self, name: str | None = None, label_selector: str | None = None
+        self,
+        name: str | None = None,
+        label_selector: str | None = None,
     ) -> list[BoundCertificate]:
         """Get all certificates
 

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -34,8 +34,13 @@ class BoundCertificate(BoundModelBase):
             )
         super().__init__(client, data, complete)
 
-    def get_actions_list(self, status=None, sort=None, page=None, per_page=None):
-        # type: (Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction, Meta]]
+    def get_actions_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Certificate.
 
         :param status: List[str] (optional)
@@ -50,8 +55,9 @@ class BoundCertificate(BoundModelBase):
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
-    def get_actions(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for a Certificate.
 
         :param status: List[str] (optional)
@@ -62,8 +68,9 @@ class BoundCertificate(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def update(self, name=None, labels=None):
-        # type: (Optional[str], Optional[Dict[str, str]]) -> BoundCertificate
+    def update(
+        self, name: str | None = None, labels: dict[str, str] | None = None
+    ) -> BoundCertificate:
         """Updates an certificate. You can update an certificate name and the certificate labels.
 
         :param name: str (optional)
@@ -74,15 +81,13 @@ class BoundCertificate(BoundModelBase):
         """
         return self._client.update(self, name, labels)
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes a certificate.
         :return: boolean
         """
         return self._client.delete(self)
 
-    def retry_issuance(self):
-        # type: () -> BoundAction
+    def retry_issuance(self) -> BoundAction:
         """Retry a failed Certificate issuance or renewal.
         :return: BoundAction
         """
@@ -97,8 +102,7 @@ class CertificatesPageResult(NamedTuple):
 class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundCertificate
+    def get_by_id(self, id: int) -> BoundCertificate:
         """Get a specific certificate by its ID.
 
         :param id: int
@@ -109,12 +113,11 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundCertificate], Meta]
+        name: str | None = None,
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> CertificatesPageResult:
         """Get a list of certificates
 
         :param name: str (optional)
@@ -151,8 +154,9 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
 
         return CertificatesPageResult(certificates, Meta.parse_meta(response))
 
-    def get_all(self, name=None, label_selector=None):
-        # type: (Optional[str], Optional[str]) -> List[BoundCertificate]
+    def get_all(
+        self, name: str | None = None, label_selector: str | None = None
+    ) -> list[BoundCertificate]:
         """Get all certificates
 
         :param name: str (optional)
@@ -163,8 +167,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundCertificate
+    def get_by_name(self, name: str) -> BoundCertificate:
         """Get certificate by name
 
         :param name: str
@@ -173,8 +176,13 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_by_name(name)
 
-    def create(self, name, certificate, private_key, labels=None):
-        # type: (str, str, str, Optional[Dict[str, str]]) -> BoundCertificate
+    def create(
+        self,
+        name: str,
+        certificate: str,
+        private_key: str,
+        labels: dict[str, str] | None = None,
+    ) -> BoundCertificate:
         """Creates a new Certificate with the given name, certificate and private_key. This methods allows only creating
            custom uploaded certificates. If you want to create a managed certificate use :func:`~hcloud.certificates.client.CertificatesClient.create_managed`
 
@@ -198,8 +206,12 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         response = self._client.request(url="/certificates", method="POST", json=data)
         return BoundCertificate(self, response["certificate"])
 
-    def create_managed(self, name, domain_names, labels=None):
-        # type: (str, List[str], Optional[Dict[str, str]]) -> CreateManagedCertificateResponse
+    def create_managed(
+        self,
+        name: str,
+        domain_names: list[str],
+        labels: dict[str, str] | None = None,
+    ) -> CreateManagedCertificateResponse:
         """Creates a new managed Certificate with the given name and domain names. This methods allows only creating
            managed certificates for domains that are using the Hetzner DNS service. If you want to create a custom uploaded certificate use :func:`~hcloud.certificates.client.CertificatesClient.create`
 
@@ -223,8 +235,12 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
             action=BoundAction(self._client.actions, response["action"]),
         )
 
-    def update(self, certificate, name=None, labels=None):
-        # type: (Certificate,  Optional[str],  Optional[Dict[str, str]]) -> BoundCertificate
+    def update(
+        self,
+        certificate: Certificate,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundCertificate:
         """Updates a Certificate. You can update a certificate name and labels.
 
         :param certificate: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>` or  :class:`Certificate <hcloud.certificates.domain.Certificate>`
@@ -246,8 +262,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundCertificate(self, response["certificate"])
 
-    def delete(self, certificate):
-        # type: (Certificate) -> bool
+    def delete(self, certificate: Certificate) -> bool:
         self._client.request(
             url=f"/certificates/{certificate.id}",
             method="DELETE",
@@ -261,9 +276,13 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def get_actions_list(
-        self, certificate, status=None, sort=None, page=None, per_page=None
-    ):
-        # type: (Certificate, Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction], Meta]
+        self,
+        certificate: Certificate,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Certificate.
 
         :param certificate: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>` or :class:`Certificate <hcloud.certificates.domain.Certificate>`
@@ -300,8 +319,12 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return ActionsPageResult(actions, Meta.parse_meta(response))
 
-    def get_actions(self, certificate, status=None, sort=None):
-        # type: (Certificate, Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self,
+        certificate: Certificate,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for a Certificate.
 
         :param certificate: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>` or :class:`Certificate <hcloud.certificates.domain.Certificate>`
@@ -313,8 +336,7 @@ class CertificatesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(certificate, status=status, sort=sort)
 
-    def retry_issuance(self, certificate):
-        # type: (Certificate) -> BoundAction
+    def retry_issuance(self, certificate: Certificate) -> BoundAction:
         """Returns all action objects for a Certificate.
 
         :param certificate: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>` or :class:`Certificate <hcloud.certificates.domain.Certificate>`

--- a/hcloud/certificates/domain.py
+++ b/hcloud/certificates/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain, DomainIdentityMixin
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundCertificate
 
 
 class Certificate(BaseDomain, DomainIdentityMixin):
@@ -112,8 +118,8 @@ class CreateManagedCertificateResponse(BaseDomain):
 
     def __init__(
         self,
-        certificate,  # type: BoundCertificate
-        action,  # type: BoundAction
+        certificate: BoundCertificate,
+        action: BoundAction,
     ):
         self.certificate = certificate
         self.action = action

--- a/hcloud/certificates/domain.py
+++ b/hcloud/certificates/domain.py
@@ -49,17 +49,17 @@ class Certificate(BaseDomain, DomainIdentityMixin):
 
     def __init__(
         self,
-        id=None,
-        name=None,
-        certificate=None,
-        not_valid_before=None,
-        not_valid_after=None,
-        domain_names=None,
-        fingerprint=None,
-        created=None,
-        labels=None,
-        type=None,
-        status=None,
+        id: int | None = None,
+        name: str | None = None,
+        certificate: str | None = None,
+        not_valid_before: str | None = None,
+        not_valid_after: str | None = None,
+        domain_names: list[str] | None = None,
+        fingerprint: str | None = None,
+        created: str | None = None,
+        labels: dict[str, str] | None = None,
+        type: str | None = None,
+        status: ManagedCertificateStatus | None = None,
     ):
         self.id = id
         self.name = name
@@ -85,7 +85,12 @@ class ManagedCertificateStatus(BaseDomain):
           If issuance or renewal reports failure, this property contains information about what happened
     """
 
-    def __init__(self, issuance=None, renewal=None, error=None):
+    def __init__(
+        self,
+        issuance: str | None = None,
+        renewal: str | None = None,
+        error: ManagedCertificateError | None = None,
+    ):
         self.issuance = issuance
         self.renewal = renewal
         self.error = error
@@ -100,7 +105,7 @@ class ManagedCertificateError(BaseDomain):
         Message detailing the error
     """
 
-    def __init__(self, code=None, message=None):
+    def __init__(self, code: str | None = None, message: str | None = None):
         self.code = code
         self.message = message
 

--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Callable
+
 
 class ClientEntityBase:
     max_per_page = 50
@@ -13,11 +15,10 @@ class ClientEntityBase:
 
     def _get_all(
         self,
-        list_function,  # type: function
+        list_function: Callable,
         *args,
         **kwargs,
-    ):
-        # type (...) -> List[BoundModelBase]
+    ) -> list[BoundModelBase]:
         results = []
 
         page = 1
@@ -42,12 +43,10 @@ class ClientEntityBase:
 
         return results
 
-    def get_all(self, *args, **kwargs):
-        # type: (...) -> List[BoundModelBase]
+    def get_all(self, *args, **kwargs) -> list[BoundModelBase]:
         return self._get_all(self.get_list, *args, **kwargs)
 
-    def get_actions(self, *args, **kwargs):
-        # type: (...) -> List[BoundModelBase]
+    def get_actions(self, *args, **kwargs) -> list[BoundModelBase]:
         if not hasattr(self, "get_actions_list"):
             raise ValueError("this endpoint does not support get_actions method")
 
@@ -59,8 +58,7 @@ class GetEntityByNameMixin:
     Use as a mixin for ClientEntityBase classes
     """
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundModelBase
+    def get_by_name(self, name: str) -> BoundModelBase:
         entities, _ = self.get_list(name=name)
         return entities[0] if entities else None
 

--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 class ClientEntityBase:
     max_per_page = 50
-    results_list_attribute_name = None
 
     def __init__(self, client):
         """

--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from .._client import Client
+    from ..actions import BoundAction
 
 
 class ClientEntityBase:
-    max_per_page = 50
+    _client: Client
 
-    def __init__(self, client):
+    max_per_page: int = 50
+
+    def __init__(self, client: Client):
         """
         :param client: Client
         :return self
@@ -18,7 +24,7 @@ class ClientEntityBase:
         list_function: Callable,
         *args,
         **kwargs,
-    ) -> list[BoundModelBase]:
+    ) -> list:
         results = []
 
         page = 1
@@ -39,14 +45,15 @@ class ClientEntityBase:
             ):
                 page = meta.pagination.next_page
             else:
-                page = None
+                page = 0
 
         return results
 
-    def get_all(self, *args, **kwargs) -> list[BoundModelBase]:
+    def get_all(self, *args, **kwargs) -> list:
+        assert hasattr(self, "get_list")
         return self._get_all(self.get_list, *args, **kwargs)
 
-    def get_actions(self, *args, **kwargs) -> list[BoundModelBase]:
+    def get_actions(self, *args, **kwargs) -> list[BoundAction]:
         if not hasattr(self, "get_actions_list"):
             raise ValueError("this endpoint does not support get_actions method")
 
@@ -58,7 +65,8 @@ class GetEntityByNameMixin:
     Use as a mixin for ClientEntityBase classes
     """
 
-    def get_by_name(self, name: str) -> BoundModelBase:
+    def get_by_name(self, name: str):
+        assert hasattr(self, "get_list")
         entities, _ = self.get_list(name=name)
         return entities[0] if entities else None
 
@@ -66,9 +74,14 @@ class GetEntityByNameMixin:
 class BoundModelBase:
     """Bound Model Base"""
 
-    model = None
+    model: Any
 
-    def __init__(self, client, data={}, complete=True):
+    def __init__(
+        self,
+        client: ClientEntityBase,
+        data: dict,
+        complete: bool = True,
+    ):
         """
         :param client:
                 The client for the specific model to use
@@ -81,7 +94,7 @@ class BoundModelBase:
         self.complete = complete
         self.data_model = self.model.from_dict(data)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         """Allow magical access to the properties of the model
         :param name: str
         :return:

--- a/hcloud/core/domain.py
+++ b/hcloud/core/domain.py
@@ -5,20 +5,23 @@ class BaseDomain:
     __slots__ = ()
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: dict):
         supported_data = {k: v for k, v in data.items() if k in cls.__slots__}
         return cls(**supported_data)
 
     def __repr__(self) -> str:
-        kwargs = [f"{key}={getattr(self, key)!r}" for key in self.__slots__]
+        kwargs = [f"{key}={getattr(self, key)!r}" for key in self.__slots__]  # type: ignore[var-annotated]
         return f"{self.__class__.__qualname__}({', '.join(kwargs)})"
 
 
 class DomainIdentityMixin:
     __slots__ = ()
 
+    id: int | None
+    name: str | None
+
     @property
-    def id_or_name(self):
+    def id_or_name(self) -> int | str:
         if self.id is not None:
             return self.id
         elif self.name is not None:
@@ -39,12 +42,12 @@ class Pagination(BaseDomain):
 
     def __init__(
         self,
-        page,
-        per_page,
-        previous_page=None,
-        next_page=None,
-        last_page=None,
-        total_entries=None,
+        page: int,
+        per_page: int,
+        previous_page: int | None = None,
+        next_page: int | None = None,
+        last_page: int | None = None,
+        total_entries: int | None = None,
     ):
         self.page = page
         self.per_page = per_page
@@ -57,7 +60,7 @@ class Pagination(BaseDomain):
 class Meta(BaseDomain):
     __slots__ = ("pagination",)
 
-    def __init__(self, pagination=None):
+    def __init__(self, pagination: Pagination | None = None):
         self.pagination = pagination
 
     @classmethod

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from ..locations import BoundLocation
@@ -16,7 +16,7 @@ class BoundDatacenter(BoundModelBase):
 
     model = Datacenter
 
-    def __init__(self, client, data):
+    def __init__(self, client: DatacentersClient, data: dict):
         location = data.get("location")
         if location is not None:
             data["location"] = BoundLocation(client._client.locations, location)
@@ -83,7 +83,7 @@ class DatacentersClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundDatacenter <hcloud.datacenters.client.BoundDatacenter>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
 
@@ -111,7 +111,7 @@ class DatacentersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name: str) -> BoundDatacenter:
+    def get_by_name(self, name: str) -> BoundDatacenter | None:
         """Get datacenter by name
 
         :param name: str

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -58,8 +58,7 @@ class DatacentersPageResult(NamedTuple):
 class DatacentersClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundDatacenter
+    def get_by_id(self, id: int) -> BoundDatacenter:
         """Get a specific datacenter by its ID.
 
         :param id: int
@@ -70,11 +69,10 @@ class DatacentersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundDatacenter], Meta]
+        name: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> DatacentersPageResult:
         """Get a list of datacenters
 
         :param name: str (optional)
@@ -104,8 +102,7 @@ class DatacentersClient(ClientEntityBase, GetEntityByNameMixin):
 
         return DatacentersPageResult(datacenters, Meta.parse_meta(response))
 
-    def get_all(self, name=None):
-        # type: (Optional[str]) -> List[BoundDatacenter]
+    def get_all(self, name: str | None = None) -> list[BoundDatacenter]:
         """Get all datacenters
 
         :param name: str (optional)
@@ -114,8 +111,7 @@ class DatacentersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundDatacenter
+    def get_by_name(self, name: str) -> BoundDatacenter:
         """Get datacenter by name
 
         :param name: str

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -16,7 +16,12 @@ class Datacenter(BaseDomain, DomainIdentityMixin):
     __slots__ = ("id", "name", "description", "location", "server_types")
 
     def __init__(
-        self, id=None, name=None, description=None, location=None, server_types=None
+        self,
+        id=None,
+        name=None,
+        description=None,
+        location=None,
+        server_types=None,
     ):
         self.id = id
         self.name = name

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..core import BaseDomain, DomainIdentityMixin
+
+if TYPE_CHECKING:
+    from ..locations import Location
+    from ..server_types import BoundServerType
 
 
 class Datacenter(BaseDomain, DomainIdentityMixin):
@@ -17,11 +23,11 @@ class Datacenter(BaseDomain, DomainIdentityMixin):
 
     def __init__(
         self,
-        id=None,
-        name=None,
-        description=None,
-        location=None,
-        server_types=None,
+        id: int | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        location: Location | None = None,
+        server_types: DatacenterServerTypes | None = None,
     ):
         self.id = id
         self.name = name
@@ -43,7 +49,12 @@ class DatacenterServerTypes:
 
     __slots__ = ("available", "supported", "available_for_migration")
 
-    def __init__(self, available, supported, available_for_migration):
+    def __init__(
+        self,
+        available: list[BoundServerType],
+        supported: list[BoundServerType],
+        available_for_migration: list[BoundServerType],
+    ):
         self.available = available
         self.supported = supported
         self.available_for_migration = available_for_migration

--- a/hcloud/deprecation/domain.py
+++ b/hcloud/deprecation/domain.py
@@ -24,8 +24,8 @@ class DeprecationInfo(BaseDomain):
 
     def __init__(
         self,
-        announced=None,
-        unavailable_after=None,
+        announced: str | None = None,
+        unavailable_after: str | None = None,
     ):
         self.announced = isoparse(announced) if announced else None
         self.unavailable_after = (

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -87,7 +87,9 @@ class BoundFirewall(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a Firewall.
 
@@ -131,7 +133,8 @@ class BoundFirewall(BoundModelBase):
         return self._client.set_rules(self, rules)
 
     def apply_to_resources(
-        self, resources: list[FirewallResource]
+        self,
+        resources: list[FirewallResource],
     ) -> list[BoundAction]:
         """Applies one Firewall to multiple resources.
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
@@ -140,7 +143,8 @@ class BoundFirewall(BoundModelBase):
         return self._client.apply_to_resources(self, resources)
 
     def remove_from_resources(
-        self, resources: list[FirewallResource]
+        self,
+        resources: list[FirewallResource],
     ) -> list[BoundAction]:
         """Removes one Firewall from multiple resources.
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
@@ -379,7 +383,9 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def set_rules(
-        self, firewall: Firewall, rules: list[FirewallRule]
+        self,
+        firewall: Firewall,
+        rules: list[FirewallRule],
     ) -> list[BoundAction]:
         """Sets the rules of a Firewall. All existing rules will be overwritten. Pass an empty rules array to remove all rules.
 
@@ -400,7 +406,9 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         return [BoundAction(self._client.actions, _) for _ in response["actions"]]
 
     def apply_to_resources(
-        self, firewall: Firewall, resources: list[FirewallResource]
+        self,
+        firewall: Firewall,
+        resources: list[FirewallResource],
     ) -> list[BoundAction]:
         """Applies one Firewall to multiple resources.
 
@@ -421,7 +429,9 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         return [BoundAction(self._client.actions, _) for _ in response["actions"]]
 
     def remove_from_resources(
-        self, firewall: Firewall, resources: list[FirewallResource]
+        self,
+        firewall: Firewall,
+        resources: list[FirewallResource],
     ) -> list[BoundAction]:
         """Removes one Firewall from multiple resources.
 

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -65,8 +65,13 @@ class BoundFirewall(BoundModelBase):
 
         super().__init__(client, data, complete)
 
-    def get_actions_list(self, status=None, sort=None, page=None, per_page=None):
-        # type: (Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResult[BoundAction, Meta]
+    def get_actions_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Firewall.
 
         :param status: List[str] (optional)
@@ -81,8 +86,9 @@ class BoundFirewall(BoundModelBase):
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
-    def get_actions(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for a Firewall.
 
         :param status: List[str] (optional)
@@ -94,8 +100,11 @@ class BoundFirewall(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def update(self, name=None, labels=None):
-        # type: (Optional[str], Optional[Dict[str, str]], Optional[str]) -> BoundFirewall
+    def update(
+        self: str | None,
+        name: dict[str, str] | None = None,
+        labels: str | None = None,
+    ) -> BoundFirewall:
         """Updates the name or labels of a Firewall.
 
         :param labels: Dict[str, str] (optional)
@@ -106,16 +115,14 @@ class BoundFirewall(BoundModelBase):
         """
         return self._client.update(self, labels, name)
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes a Firewall.
 
         :return: boolean
         """
         return self._client.delete(self)
 
-    def set_rules(self, rules):
-        # type: (List[FirewallRule]) -> List[BoundAction]
+    def set_rules(self, rules: list[FirewallRule]) -> list[BoundAction]:
         """Sets the rules of a Firewall. All existing rules will be overwritten. Pass an empty rules array to remove all rules.
         :param rules: List[:class:`FirewallRule <hcloud.firewalls.domain.FirewallRule>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
@@ -123,16 +130,18 @@ class BoundFirewall(BoundModelBase):
 
         return self._client.set_rules(self, rules)
 
-    def apply_to_resources(self, resources):
-        # type: (List[FirewallResource]) -> List[BoundAction]
+    def apply_to_resources(
+        self, resources: list[FirewallResource]
+    ) -> list[BoundAction]:
         """Applies one Firewall to multiple resources.
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
         return self._client.apply_to_resources(self, resources)
 
-    def remove_from_resources(self, resources):
-        # type: (List[FirewallResource]) -> List[BoundAction]
+    def remove_from_resources(
+        self, resources: list[FirewallResource]
+    ) -> list[BoundAction]:
         """Removes one Firewall from multiple resources.
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
@@ -150,13 +159,12 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        firewall,  # type: Firewall
-        status=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundAction], Meta]
+        firewall: Firewall,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Firewall.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -192,11 +200,10 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        firewall,  # type: Firewall
-        status=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> List[BoundAction]
+        firewall: Firewall,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for a Firewall.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -209,8 +216,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(firewall, status=status, sort=sort)
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundFirewall
+    def get_by_id(self, id: int) -> BoundFirewall:
         """Returns a specific Firewall object.
 
         :param id: int
@@ -221,13 +227,12 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        name=None,  # type: Optional[str]
-        sort=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> PageResults[List[BoundFirewall]]
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        name: str | None = None,
+        sort: list[str] | None = None,
+    ) -> FirewallsPageResult:
         """Get a list of floating ips from this account
 
         :param label_selector: str (optional)
@@ -262,8 +267,12 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
         return FirewallsPageResult(firewalls, Meta.parse_meta(response))
 
-    def get_all(self, label_selector=None, name=None, sort=None):
-        # type: (Optional[str], Optional[str],  Optional[List[str]]) -> List[BoundFirewall]
+    def get_all(
+        self,
+        label_selector: str | None = None,
+        name: str | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundFirewall]:
         """Get all floating ips from this account
 
         :param label_selector: str (optional)
@@ -276,8 +285,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name, sort=sort)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundFirewall
+    def get_by_name(self, name: str) -> BoundFirewall:
         """Get Firewall by name
 
         :param name: str
@@ -288,12 +296,11 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        name,  # type: str
-        rules=None,  # type: Optional[List[FirewallRule]]
-        labels=None,  # type: Optional[str]
-        resources=None,  # type: Optional[List[FirewallResource]]
-    ):
-        # type: (...) -> CreateFirewallResponse
+        name: str,
+        rules: list[FirewallRule] | None = None,
+        labels: str | None = None,
+        resources: list[FirewallResource] | None = None,
+    ) -> CreateFirewallResponse:
         """Creates a new Firewall.
 
         :param name: str
@@ -330,8 +337,12 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return result
 
-    def update(self, firewall, labels=None, name=None):
-        # type: (Firewall,   Optional[Dict[str, str]], Optional[str]) -> BoundFirewall
+    def update(
+        self,
+        firewall: Firewall,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundFirewall:
         """Updates the description or labels of a Firewall.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -354,8 +365,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundFirewall(self, response["firewall"])
 
-    def delete(self, firewall):
-        # type: (Firewall) -> bool
+    def delete(self, firewall: Firewall) -> bool:
         """Deletes a Firewall.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -368,8 +378,9 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         # Return always true, because the API does not return an action for it. When an error occurs a HcloudAPIException will be raised
         return True
 
-    def set_rules(self, firewall, rules):
-        # type: (Firewall, List[FirewallRule]) -> List[BoundAction]
+    def set_rules(
+        self, firewall: Firewall, rules: list[FirewallRule]
+    ) -> list[BoundAction]:
         """Sets the rules of a Firewall. All existing rules will be overwritten. Pass an empty rules array to remove all rules.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -388,8 +399,9 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return [BoundAction(self._client.actions, _) for _ in response["actions"]]
 
-    def apply_to_resources(self, firewall, resources):
-        # type: (Firewall, List[FirewallResource]) -> List[BoundAction]
+    def apply_to_resources(
+        self, firewall: Firewall, resources: list[FirewallResource]
+    ) -> list[BoundAction]:
         """Applies one Firewall to multiple resources.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -408,8 +420,9 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return [BoundAction(self._client.actions, _) for _ in response["actions"]]
 
-    def remove_from_resources(self, firewall, resources):
-        # type: (Firewall, List[FirewallResource]) -> List[BoundAction]
+    def remove_from_resources(
+        self, firewall: Firewall, resources: list[FirewallResource]
+    ) -> list[BoundAction]:
         """Removes one Firewall from multiple resources.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -21,7 +21,7 @@ class BoundFirewall(BoundModelBase):
 
     model = Firewall
 
-    def __init__(self, client, data, complete=True):
+    def __init__(self, client: FirewallsClient, data: dict, complete: bool = True):
         rules = data.get("rules", [])
         if rules:
             rules = [
@@ -103,9 +103,9 @@ class BoundFirewall(BoundModelBase):
         return self._client.get_actions(self, status, sort)
 
     def update(
-        self: str | None,
-        name: dict[str, str] | None = None,
-        labels: str | None = None,
+        self,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> BoundFirewall:
         """Updates the name or labels of a Firewall.
 
@@ -163,7 +163,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        firewall: Firewall,
+        firewall: Firewall | BoundFirewall,
         status: list[str] | None = None,
         sort: list[str] | None = None,
         page: int | None = None,
@@ -182,7 +182,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if status is not None:
             params["status"] = status
         if sort is not None:
@@ -204,7 +204,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        firewall: Firewall,
+        firewall: Firewall | BoundFirewall,
         status: list[str] | None = None,
         sort: list[str] | None = None,
     ) -> list[BoundAction]:
@@ -251,7 +251,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
                Choices: id name created (You can add one of ":asc", ":desc" to modify sort order. ( ":asc" is default))
         :return: (List[:class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
 
         if label_selector is not None:
             params["label_selector"] = label_selector
@@ -289,7 +289,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name, sort=sort)
 
-    def get_by_name(self, name: str) -> BoundFirewall:
+    def get_by_name(self, name: str) -> BoundFirewall | None:
         """Get Firewall by name
 
         :param name: str
@@ -316,7 +316,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         :return: :class:`CreateFirewallResponse <hcloud.firewalls.domain.CreateFirewallResponse>`
         """
 
-        data = {"name": name}
+        data: dict[str, Any] = {"name": name}
         if labels is not None:
             data["labels"] = labels
 
@@ -343,7 +343,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        firewall: Firewall,
+        firewall: Firewall | BoundFirewall,
         labels: dict[str, str] | None = None,
         name: str | None = None,
     ) -> BoundFirewall:
@@ -356,7 +356,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
                New name to set
         :return: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if labels is not None:
             data["labels"] = labels
         if name is not None:
@@ -369,7 +369,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundFirewall(self, response["firewall"])
 
-    def delete(self, firewall: Firewall) -> bool:
+    def delete(self, firewall: Firewall | BoundFirewall) -> bool:
         """Deletes a Firewall.
 
         :param firewall: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>` or  :class:`Firewall <hcloud.firewalls.domain.Firewall>`
@@ -384,7 +384,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def set_rules(
         self,
-        firewall: Firewall,
+        firewall: Firewall | BoundFirewall,
         rules: list[FirewallRule],
     ) -> list[BoundAction]:
         """Sets the rules of a Firewall. All existing rules will be overwritten. Pass an empty rules array to remove all rules.
@@ -393,7 +393,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         :param rules: List[:class:`FirewallRule <hcloud.firewalls.domain.FirewallRule>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        data = {"rules": []}
+        data: dict[str, Any] = {"rules": []}
         for rule in rules:
             data["rules"].append(rule.to_payload())
         response = self._client.request(
@@ -407,7 +407,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def apply_to_resources(
         self,
-        firewall: Firewall,
+        firewall: Firewall | BoundFirewall,
         resources: list[FirewallResource],
     ) -> list[BoundAction]:
         """Applies one Firewall to multiple resources.
@@ -416,7 +416,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        data = {"apply_to": []}
+        data: dict[str, Any] = {"apply_to": []}
         for resource in resources:
             data["apply_to"].append(resource.to_payload())
         response = self._client.request(
@@ -430,7 +430,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def remove_from_resources(
         self,
-        firewall: Firewall,
+        firewall: Firewall | BoundFirewall,
         resources: list[FirewallResource],
     ) -> list[BoundAction]:
         """Removes one Firewall from multiple resources.
@@ -439,7 +439,7 @@ class FirewallsClient(ClientEntityBase, GetEntityByNameMixin):
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        data = {"remove_from": []}
+        data: dict[str, Any] = {"remove_from": []}
         for resource in resources:
             data["remove_from"].append(resource.to_payload())
         response = self._client.request(

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from ..servers import Server
+    from .client import BoundFirewall
 
 
 class Firewall(BaseDomain):
@@ -80,12 +87,12 @@ class FirewallRule:
 
     def __init__(
         self,
-        direction,  # type: str
-        protocol,  # type: str
-        source_ips,  # type: List[str]
-        port=None,  # type: Optional[str]
-        destination_ips=None,  # type: Optional[List[str]]
-        description=None,  # type: Optional[str]
+        direction: str,
+        protocol: str,
+        source_ips: list[str],
+        port: str | None = None,
+        destination_ips: list[str] | None = None,
+        description: str | None = None,
     ):
         self.direction = direction
         self.port = port
@@ -129,9 +136,9 @@ class FirewallResource:
 
     def __init__(
         self,
-        type,  # type: str
-        server=None,  # type: Optional[Server]
-        label_selector=None,  # type: Optional[FirewallResourceLabelSelector]
+        type: str,
+        server: Server | None = None,
+        label_selector: FirewallResourceLabelSelector | None = None,
     ):
         self.type = type
         self.server = server
@@ -172,8 +179,8 @@ class CreateFirewallResponse(BaseDomain):
 
     def __init__(
         self,
-        firewall,  # type: BoundFirewall
-        actions,  # type: BoundAction
+        firewall: BoundFirewall,
+        actions: BoundAction,
     ):
         self.firewall = firewall
         self.actions = actions

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -8,7 +8,7 @@ from ..core import BaseDomain
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
-    from ..servers import Server
+    from ..servers import BoundServer, Server
     from .client import BoundFirewall
 
 
@@ -143,7 +143,7 @@ class FirewallResource:
     def __init__(
         self,
         type: str,
-        server: Server | None = None,
+        server: Server | BoundServer | None = None,
         label_selector: FirewallResourceLabelSelector | None = None,
     ):
         self.type = type
@@ -186,7 +186,7 @@ class CreateFirewallResponse(BaseDomain):
     def __init__(
         self,
         firewall: BoundFirewall,
-        actions: BoundAction,
+        actions: list[BoundAction] | None,
     ):
         self.firewall = firewall
         self.actions = actions

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -32,7 +32,13 @@ class Firewall(BaseDomain):
     __slots__ = ("id", "name", "labels", "rules", "applied_to", "created")
 
     def __init__(
-        self, id=None, name=None, labels=None, rules=None, applied_to=None, created=None
+        self,
+        id=None,
+        name=None,
+        labels=None,
+        rules=None,
+        applied_to=None,
+        created=None,
     ):
         self.id = id
         self.name = name

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -57,7 +57,9 @@ class BoundFloatingIP(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a Floating IP.
 
@@ -251,7 +253,9 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return FloatingIPsPageResult(floating_ips, Meta.parse_meta(response))
 
     def get_all(
-        self, label_selector: str | None = None, name: str | None = None
+        self,
+        label_selector: str | None = None,
+        name: str | None = None,
     ) -> list[BoundFloatingIP]:
         """Get all floating ips from this account
 
@@ -366,7 +370,9 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def change_protection(
-        self, floating_ip: FloatingIP, delete: bool | None = None
+        self,
+        floating_ip: FloatingIP,
+        delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of the Floating IP.
 
@@ -420,7 +426,10 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def change_dns_ptr(
-        self, floating_ip: FloatingIP, ip: str, dns_ptr: str
+        self,
+        floating_ip: FloatingIP,
+        ip: str,
+        dns_ptr: str,
     ) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to this Floating IP.
 

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -9,6 +9,8 @@ from .domain import CreateFloatingIPResponse, FloatingIP
 
 if TYPE_CHECKING:
     from .._client import Client
+    from ..locations import Location
+    from ..servers import Server
 
 
 class BoundFloatingIP(BoundModelBase):
@@ -33,8 +35,13 @@ class BoundFloatingIP(BoundModelBase):
 
         super().__init__(client, data, complete)
 
-    def get_actions_list(self, status=None, sort=None, page=None, per_page=None):
-        # type: (Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResult[BoundAction, Meta]
+    def get_actions_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Floating IP.
 
         :param status: List[str] (optional)
@@ -49,8 +56,9 @@ class BoundFloatingIP(BoundModelBase):
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
-    def get_actions(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for a Floating IP.
 
         :param status: List[str] (optional)
@@ -62,8 +70,12 @@ class BoundFloatingIP(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def update(self, description=None, labels=None, name=None):
-        # type: (Optional[str], Optional[Dict[str, str]], Optional[str]) -> BoundFloatingIP
+    def update(
+        self,
+        description: str | None = None,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundFloatingIP:
         """Updates the description or labels of a Floating IP.
 
         :param description: str (optional)
@@ -76,16 +88,14 @@ class BoundFloatingIP(BoundModelBase):
         """
         return self._client.update(self, description, labels, name)
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes a Floating IP. If it is currently assigned to a server it will automatically get unassigned.
 
         :return: boolean
         """
         return self._client.delete(self)
 
-    def change_protection(self, delete=None):
-        # type: (Optional[bool]) -> BoundAction
+    def change_protection(self, delete: bool | None = None) -> BoundAction:
         """Changes the protection configuration of the Floating IP.
 
         :param delete: boolean
@@ -94,8 +104,7 @@ class BoundFloatingIP(BoundModelBase):
         """
         return self._client.change_protection(self, delete)
 
-    def assign(self, server):
-        # type: (Server) -> BoundAction
+    def assign(self, server: Server) -> BoundAction:
         """Assigns a Floating IP to a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -104,16 +113,14 @@ class BoundFloatingIP(BoundModelBase):
         """
         return self._client.assign(self, server)
 
-    def unassign(self):
-        # type: () -> BoundAction
+    def unassign(self) -> BoundAction:
         """Unassigns a Floating IP, resulting in it being unreachable. You may assign it to a server again at a later time.
 
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.unassign(self)
 
-    def change_dns_ptr(self, ip, dns_ptr):
-        # type: (str, str) -> BoundAction
+    def change_dns_ptr(self, ip: str, dns_ptr: str) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to this Floating IP.
 
         :param ip: str
@@ -135,13 +142,12 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        floating_ip,  # type: FloatingIP
-        status=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundAction], Meta]
+        floating_ip: FloatingIP,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Floating IP.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -179,11 +185,10 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        floating_ip,  # type: FloatingIP
-        status=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> List[BoundAction]
+        floating_ip: FloatingIP,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for a Floating IP.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -196,8 +201,7 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(floating_ip, status=status, sort=sort)
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundFloatingIP
+    def get_by_id(self, id: int) -> BoundFloatingIP:
         """Returns a specific Floating IP object.
 
         :param id: int
@@ -208,12 +212,11 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        name=None,  # type: Optional[str]
-    ):
-        # type: (...) -> PageResults[List[BoundFloatingIP]]
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        name: str | None = None,
+    ) -> FloatingIPsPageResult:
         """Get a list of floating ips from this account
 
         :param label_selector: str (optional)
@@ -247,8 +250,9 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
         return FloatingIPsPageResult(floating_ips, Meta.parse_meta(response))
 
-    def get_all(self, label_selector=None, name=None):
-        # type: (Optional[str], Optional[str]) -> List[BoundFloatingIP]
+    def get_all(
+        self, label_selector: str | None = None, name: str | None = None
+    ) -> list[BoundFloatingIP]:
         """Get all floating ips from this account
 
         :param label_selector: str (optional)
@@ -259,8 +263,7 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundFloatingIP
+    def get_by_name(self, name: str) -> BoundFloatingIP:
         """Get Floating IP by name
 
         :param name: str
@@ -271,14 +274,13 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        type,  # type: str
-        description=None,  # type: Optional[str]
-        labels=None,  # type: Optional[str]
-        home_location=None,  # type: Optional[Location]
-        server=None,  # type: Optional[Server]
-        name=None,  # type: Optional[str]
-    ):
-        # type: (...) -> CreateFloatingIPResponse
+        type: str,
+        description: str | None = None,
+        labels: str | None = None,
+        home_location: Location | None = None,
+        server: Server | None = None,
+        name: str | None = None,
+    ) -> CreateFloatingIPResponse:
         """Creates a new Floating IP assigned to a server.
 
         :param type: str
@@ -317,8 +319,13 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return result
 
-    def update(self, floating_ip, description=None, labels=None, name=None):
-        # type: (FloatingIP,  Optional[str], Optional[Dict[str, str]], Optional[str]) -> BoundFloatingIP
+    def update(
+        self,
+        floating_ip: FloatingIP,
+        description: str | None = None,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundFloatingIP:
         """Updates the description or labels of a Floating IP.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -345,8 +352,7 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundFloatingIP(self, response["floating_ip"])
 
-    def delete(self, floating_ip):
-        # type: (FloatingIP) -> bool
+    def delete(self, floating_ip: FloatingIP) -> bool:
         """Deletes a Floating IP. If it is currently assigned to a server it will automatically get unassigned.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -359,8 +365,9 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         # Return always true, because the API does not return an action for it. When an error occurs a HcloudAPIException will be raised
         return True
 
-    def change_protection(self, floating_ip, delete=None):
-        # type: (FloatingIP, Optional[bool]) -> BoundAction
+    def change_protection(
+        self, floating_ip: FloatingIP, delete: bool | None = None
+    ) -> BoundAction:
         """Changes the protection configuration of the Floating IP.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -381,8 +388,7 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def assign(self, floating_ip, server):
-        # type: (FloatingIP, Server) -> BoundAction
+    def assign(self, floating_ip: FloatingIP, server: Server) -> BoundAction:
         """Assigns a Floating IP to a server.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -399,8 +405,7 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def unassign(self, floating_ip):
-        # type: (FloatingIP) -> BoundAction
+    def unassign(self, floating_ip: FloatingIP) -> BoundAction:
         """Unassigns a Floating IP, resulting in it being unreachable. You may assign it to a server again at a later time.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`
@@ -414,8 +419,9 @@ class FloatingIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_dns_ptr(self, floating_ip, ip, dns_ptr):
-        # type: (FloatingIP, str, str) -> BoundAction
+    def change_dns_ptr(
+        self, floating_ip: FloatingIP, ip: str, dns_ptr: str
+    ) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to this Floating IP.
 
         :param floating_ip: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>` or  :class:`FloatingIP <hcloud.floating_ips.domain.FloatingIP>`

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -106,7 +106,7 @@ class BoundFloatingIP(BoundModelBase):
         """
         return self._client.change_protection(self, delete)
 
-    def assign(self, server: Server) -> BoundAction:
+    def assign(self, server: Server | BoundServer) -> BoundAction:
         """Assigns a Floating IP to a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundFloatingIP
 
 
 class FloatingIP(BaseDomain):
@@ -91,8 +97,8 @@ class CreateFloatingIPResponse(BaseDomain):
 
     def __init__(
         self,
-        floating_ip,  # type: BoundFloatingIP
-        action,  # type: BoundAction
+        floating_ip: BoundFloatingIP,
+        action: BoundAction,
     ):
         self.floating_ip = floating_ip
         self.action = action

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -98,7 +98,7 @@ class CreateFloatingIPResponse(BaseDomain):
     def __init__(
         self,
         floating_ip: BoundFloatingIP,
-        action: BoundAction,
+        action: BoundAction | None,
     ):
         self.floating_ip = floating_ip
         self.action = action

--- a/hcloud/helpers/labels.py
+++ b/hcloud/helpers/labels.py
@@ -26,7 +26,7 @@ class LabelValidator:
         return True
 
     @staticmethod
-    def validate_verbose(labels: dict[str, str]) -> tuple(bool, str):
+    def validate_verbose(labels: dict[str, str]) -> tuple[bool, str]:
         """Validates Labels and returns the corresponding error message if something is wrong. Returns True, <empty string>
         if everything is fine.
 

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -55,7 +55,9 @@ class BoundImage(BoundModelBase):
         )
 
     def get_actions(
-        self, sort: list[str] | None = None, status: list[str] | None = None
+        self,
+        sort: list[str] | None = None,
+        status: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for the image.
 
@@ -349,7 +351,9 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def change_protection(
-        self, image: Image, delete: bool | None = None
+        self,
+        image: Image,
+        delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of the image. Can only be used on snapshots.
 

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -31,8 +31,13 @@ class BoundImage(BoundModelBase):
 
         super().__init__(client, data)
 
-    def get_actions_list(self, sort=None, page=None, per_page=None, status=None):
-        # type: (Optional[List[str]], Optional[int], Optional[int], Optional[List[str]]) -> PageResult[BoundAction, Meta]
+    def get_actions_list(
+        self,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        status: list[str] | None = None,
+    ) -> ActionsPageResult:
         """Returns a list of action objects for the image.
 
         :param status: List[str] (optional)
@@ -49,8 +54,9 @@ class BoundImage(BoundModelBase):
             self, sort=sort, page=page, per_page=per_page, status=status
         )
 
-    def get_actions(self, sort=None, status=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, sort: list[str] | None = None, status: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for the image.
 
         :param status: List[str] (optional)
@@ -61,8 +67,12 @@ class BoundImage(BoundModelBase):
         """
         return self._client.get_actions(self, status=status, sort=sort)
 
-    def update(self, description=None, type=None, labels=None):
-        # type: (Optional[str], Optional[str], Optional[Dict[str, str]]) -> BoundImage
+    def update(
+        self,
+        description: str | None = None,
+        type: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundImage:
         """Updates the Image. You may change the description, convert a Backup image to a Snapshot Image or change the image labels.
 
         :param description: str (optional)
@@ -76,16 +86,14 @@ class BoundImage(BoundModelBase):
         """
         return self._client.update(self, description, type, labels)
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes an Image. Only images of type snapshot and backup can be deleted.
 
         :return: bool
         """
         return self._client.delete(self)
 
-    def change_protection(self, delete=None):
-        # type: (Optional[bool]) -> BoundAction
+    def change_protection(self, delete: bool | None = None) -> BoundAction:
         """Changes the protection configuration of the image. Can only be used on snapshots.
 
         :param delete: bool
@@ -105,13 +113,12 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        image,  # type: Image
-        sort=None,  # type: Optional[List[str]]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        status=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> PageResults[List[BoundAction], Meta]
+        image: Image,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        status: list[str] | None = None,
+    ) -> ActionsPageResult:
         """Returns a list of action objects for an image.
 
         :param image: :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.images.domain.Image>`
@@ -147,11 +154,10 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        image,  # type: Image
-        sort=None,  # type: Optional[List[str]]
-        status=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> List[BoundAction]
+        image: Image,
+        sort: list[str] | None = None,
+        status: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for an image.
 
         :param image: :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.images.domain.Image>`
@@ -163,8 +169,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(image, sort=sort, status=status)
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundImage
+    def get_by_id(self, id: int) -> BoundImage:
         """Get a specific Image
 
         :param id: int
@@ -175,18 +180,17 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        bound_to=None,  # type: Optional[List[str]]
-        type=None,  # type: Optional[List[str]]
-        architecture=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        status=None,  # type: Optional[List[str]]
-        include_deprecated=None,  # type: Optional[bool]
-    ):
-        # type: (...) -> PageResults[List[BoundImage]]
+        name: str | None = None,
+        label_selector: str | None = None,
+        bound_to: list[str] | None = None,
+        type: list[str] | None = None,
+        architecture: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        status: list[str] | None = None,
+        include_deprecated: bool | None = None,
+    ) -> ImagesPageResult:
         """Get all images
 
         :param name: str (optional)
@@ -239,16 +243,15 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_all(
         self,
-        name=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        bound_to=None,  # type: Optional[List[str]]
-        type=None,  # type: Optional[List[str]]
-        architecture=None,  # type: Optional[List[str]]
-        sort=None,  # type: Optional[List[str]]
-        status=None,  # type: Optional[List[str]]
-        include_deprecated=None,  # type: Optional[bool]
-    ):
-        # type: (...) -> List[BoundImage]
+        name: str | None = None,
+        label_selector: str | None = None,
+        bound_to: list[str] | None = None,
+        type: list[str] | None = None,
+        architecture: list[str] | None = None,
+        sort: list[str] | None = None,
+        status: list[str] | None = None,
+        include_deprecated: bool | None = None,
+    ) -> list[BoundImage]:
         """Get all images
 
         :param name: str (optional)
@@ -280,8 +283,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
             include_deprecated=include_deprecated,
         )
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundImage
+    def get_by_name(self, name: str) -> BoundImage:
         """Get image by name
 
         Deprecated: Use get_by_name_and_architecture instead.
@@ -292,8 +294,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_by_name(name)
 
-    def get_by_name_and_architecture(self, name, architecture):
-        # type: (str, str) -> BoundImage
+    def get_by_name_and_architecture(self, name: str, architecture: str) -> BoundImage:
         """Get image by name
 
         :param name: str
@@ -306,8 +307,13 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         entity = entities[0] if entities else None
         return entity
 
-    def update(self, image, description=None, type=None, labels=None):
-        # type:(Image,  Optional[str], Optional[str],  Optional[Dict[str, str]]) -> BoundImage
+    def update(
+        self,
+        image: Image,
+        description: str | None = None,
+        type: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundImage:
         """Updates the Image. You may change the description, convert a Backup image to a Snapshot Image or change the image labels.
 
         :param image: :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.images.domain.Image>`
@@ -332,8 +338,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundImage(self, response["image"])
 
-    def delete(self, image):
-        # type: (Image) -> bool
+    def delete(self, image: Image) -> bool:
         """Deletes an Image. Only images of type snapshot and backup can be deleted.
 
         :param :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.images.domain.Image>`
@@ -343,8 +348,9 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         # Return allays true, because the API does not return an action for it. When an error occurs a APIException will be raised
         return True
 
-    def change_protection(self, image, delete=None):
-        # type: (Image, Optional[bool]) -> BoundAction
+    def change_protection(
+        self, image: Image, delete: bool | None = None
+    ) -> BoundAction:
         """Changes the protection configuration of the image. Can only be used on snapshots.
 
         :param image: :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.images.domain.Image>`

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -15,7 +15,7 @@ class BoundImage(BoundModelBase):
 
     model = Image
 
-    def __init__(self, client, data):
+    def __init__(self, client: ImagesClient, data: dict):
         from ..servers import BoundServer
 
         created_from = data.get("created_from")
@@ -115,7 +115,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        image: Image,
+        image: Image | BoundImage,
         sort: list[str] | None = None,
         page: int | None = None,
         per_page: int | None = None,
@@ -134,7 +134,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if sort is not None:
             params["sort"] = sort
         if status is not None:
@@ -156,7 +156,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        image: Image,
+        image: Image | BoundImage,
         sort: list[str] | None = None,
         status: list[str] | None = None,
     ) -> list[BoundAction]:
@@ -217,7 +217,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundImage <hcloud.images.client.BoundImage>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if label_selector is not None:
@@ -285,7 +285,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
             include_deprecated=include_deprecated,
         )
 
-    def get_by_name(self, name: str) -> BoundImage:
+    def get_by_name(self, name: str) -> BoundImage | None:
         """Get image by name
 
         Deprecated: Use get_by_name_and_architecture instead.
@@ -296,7 +296,11 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_by_name(name)
 
-    def get_by_name_and_architecture(self, name: str, architecture: str) -> BoundImage:
+    def get_by_name_and_architecture(
+        self,
+        name: str,
+        architecture: str,
+    ) -> BoundImage | None:
         """Get image by name
 
         :param name: str
@@ -311,7 +315,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        image: Image,
+        image: Image | BoundImage,
         description: str | None = None,
         type: str | None = None,
         labels: dict[str, str] | None = None,
@@ -328,7 +332,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundImage <hcloud.images.client.BoundImage>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if description is not None:
             data.update({"description": description})
         if type is not None:
@@ -340,7 +344,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundImage(self, response["image"])
 
-    def delete(self, image: Image) -> bool:
+    def delete(self, image: Image | BoundImage) -> bool:
         """Deletes an Image. Only images of type snapshot and backup can be deleted.
 
         :param :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.images.domain.Image>`
@@ -352,7 +356,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def change_protection(
         self,
-        image: Image,
+        image: Image | BoundImage,
         delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of the image. Can only be used on snapshots.
@@ -362,7 +366,7 @@ class ImagesClient(ClientEntityBase, GetEntityByNameMixin):
                If true, prevents the snapshot from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if delete is not None:
             data.update({"delete": delete})
 

--- a/hcloud/images/domain.py
+++ b/hcloud/images/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain, DomainIdentityMixin
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundImage
 
 
 class Image(BaseDomain, DomainIdentityMixin):
@@ -116,8 +122,8 @@ class CreateImageResponse(BaseDomain):
 
     def __init__(
         self,
-        action,  # type: BoundAction
-        image,  # type: BoundImage
+        action: BoundAction,
+        image: BoundImage,
     ):
         self.action = action
         self.image = image

--- a/hcloud/images/domain.py
+++ b/hcloud/images/domain.py
@@ -8,6 +8,7 @@ from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
+    from ..servers import BoundServer, Server
     from .client import BoundImage
 
 
@@ -72,23 +73,23 @@ class Image(BaseDomain, DomainIdentityMixin):
 
     def __init__(
         self,
-        id=None,
-        name=None,
-        type=None,
-        created=None,
-        description=None,
-        image_size=None,
-        disk_size=None,
-        deprecated=None,
-        bound_to=None,
-        os_flavor=None,
-        os_version=None,
-        architecture=None,
-        rapid_deploy=None,
-        created_from=None,
-        protection=None,
-        labels=None,
-        status=None,
+        id: int | None = None,
+        name: str | None = None,
+        type: str | None = None,
+        created: str | None = None,
+        description: str | None = None,
+        image_size: int | None = None,
+        disk_size: int | None = None,
+        deprecated: str | None = None,
+        bound_to: Server | BoundServer | None = None,
+        os_flavor: str | None = None,
+        os_version: str | None = None,
+        architecture: str | None = None,
+        rapid_deploy: bool | None = None,
+        created_from: Server | BoundServer | None = None,
+        protection: dict | None = None,
+        labels: dict[str, str] | None = None,
+        status: str | None = None,
     ):
         self.id = id
         self.name = name

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 from warnings import warn
 
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -67,7 +67,7 @@ class IsosClient(ClientEntityBase, GetEntityByNameMixin):
             )
             include_architecture_wildcard = include_wildcard_architecture
 
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if architecture is not None:
@@ -117,7 +117,7 @@ class IsosClient(ClientEntityBase, GetEntityByNameMixin):
             include_architecture_wildcard=include_architecture_wildcard,
         )
 
-    def get_by_name(self, name: str) -> BoundIso:
+    def get_by_name(self, name: str) -> BoundIso | None:
         """Get iso by name
 
         :param name: str

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -24,8 +24,7 @@ class IsosPageResult(NamedTuple):
 class IsosClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundIso
+    def get_by_id(self, id: int) -> BoundIso:
         """Get a specific ISO by its id
 
         :param id: int
@@ -36,14 +35,13 @@ class IsosClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        architecture=None,  # type: Optional[List[str]]
-        include_wildcard_architecture=None,  # type: Optional[bool]
-        include_architecture_wildcard=None,  # type: Optional[bool]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundIso], Meta]
+        name: str | None = None,
+        architecture: list[str] | None = None,
+        include_wildcard_architecture: bool | None = None,
+        include_architecture_wildcard: bool | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> IsosPageResult:
         """Get a list of ISOs
 
         :param name: str (optional)
@@ -87,12 +85,11 @@ class IsosClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_all(
         self,
-        name=None,  # type: Optional[str]
-        architecture=None,  # type: Optional[List[str]]
-        include_wildcard_architecture=None,  # type: Optional[bool]
-        include_architecture_wildcard=None,  # type: Optional[bool]
-    ):
-        # type: (...) -> List[BoundIso]
+        name: str | None = None,
+        architecture: list[str] | None = None,
+        include_wildcard_architecture: bool | None = None,
+        include_architecture_wildcard: bool | None = None,
+    ) -> list[BoundIso]:
         """Get all ISOs
 
         :param name: str (optional)
@@ -120,8 +117,7 @@ class IsosClient(ClientEntityBase, GetEntityByNameMixin):
             include_architecture_wildcard=include_architecture_wildcard,
         )
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundIso
+    def get_by_name(self, name: str) -> BoundIso:
         """Get iso by name
 
         :param name: str

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -23,8 +23,7 @@ class LoadBalancerTypesPageResult(NamedTuple):
 class LoadBalancerTypesClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> load_balancer_types.client.BoundLoadBalancerType
+    def get_by_id(self, id: int) -> BoundLoadBalancerType:
         """Returns a specific Load Balancer Type.
 
         :param id: int
@@ -38,8 +37,12 @@ class LoadBalancerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundLoadBalancerType(self, response["load_balancer_type"])
 
-    def get_list(self, name=None, page=None, per_page=None):
-        # type: (Optional[str], Optional[int], Optional[int]) -> PageResults[List[BoundLoadBalancerType], Meta]
+    def get_list(
+        self,
+        name: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> LoadBalancerTypesPageResult:
         """Get a list of Load Balancer types
 
         :param name: str (optional)
@@ -69,8 +72,7 @@ class LoadBalancerTypesClient(ClientEntityBase, GetEntityByNameMixin):
             load_balancer_types, Meta.parse_meta(response)
         )
 
-    def get_all(self, name=None):
-        # type: (Optional[str]) -> List[BoundLoadBalancerType]
+    def get_all(self, name: str | None = None) -> list[BoundLoadBalancerType]:
         """Get all Load Balancer types
 
         :param name: str (optional)
@@ -79,8 +81,7 @@ class LoadBalancerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundLoadBalancerType
+    def get_by_name(self, name: str) -> BoundLoadBalancerType:
         """Get Load Balancer type by name
 
         :param name: str

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import LoadBalancerType
@@ -53,7 +53,7 @@ class LoadBalancerTypesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundLoadBalancerType <hcloud.load_balancer_types.client.BoundLoadBalancerType>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if page is not None:
@@ -81,7 +81,7 @@ class LoadBalancerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name: str) -> BoundLoadBalancerType:
+    def get_by_name(self, name: str) -> BoundLoadBalancerType | None:
         """Get Load Balancer type by name
 
         :param name: str

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..certificates import BoundCertificate
@@ -38,7 +38,7 @@ class BoundLoadBalancer(BoundModelBase):
 
     model = LoadBalancer
 
-    def __init__(self, client, data, complete=True):
+    def __init__(self, client: LoadBalancersClient, data: dict, complete: bool = True):
         algorithm = data.get("algorithm")
         if algorithm:
             data["algorithm"] = LoadBalancerAlgorithm(type=algorithm["type"])
@@ -157,7 +157,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.update(self, name, labels)
 
-    def delete(self) -> BoundAction:
+    def delete(self) -> bool:
         """Deletes a Load Balancer.
 
         :return: boolean
@@ -200,7 +200,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def add_service(self, service: LoadBalancerService) -> list[BoundAction]:
+    def add_service(self, service: LoadBalancerService) -> BoundAction:
         """Adds a service to a Load Balancer.
 
         :param service: :class:`LoadBalancerService <hcloud.load_balancers.domain.LoadBalancerService>`
@@ -209,7 +209,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.add_service(self, service=service)
 
-    def update_service(self, service: LoadBalancerService) -> list[BoundAction]:
+    def update_service(self, service: LoadBalancerService) -> BoundAction:
         """Updates a service of an Load Balancer.
 
         :param service: :class:`LoadBalancerService <hcloud.load_balancers.domain.LoadBalancerService>`
@@ -218,7 +218,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.update_service(self, service=service)
 
-    def delete_service(self, service: LoadBalancerService) -> list[BoundAction]:
+    def delete_service(self, service: LoadBalancerService) -> BoundAction:
         """Deletes a service from a Load Balancer.
 
         :param service: :class:`LoadBalancerService <hcloud.load_balancers.domain.LoadBalancerService>`
@@ -227,7 +227,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.delete_service(self, service)
 
-    def add_target(self, target: LoadBalancerTarget) -> list[BoundAction]:
+    def add_target(self, target: LoadBalancerTarget) -> BoundAction:
         """Adds a target to a Load Balancer.
 
         :param target: :class:`LoadBalancerTarget <hcloud.load_balancers.domain.LoadBalancerTarget>`
@@ -236,7 +236,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.add_target(self, target)
 
-    def remove_target(self, target: LoadBalancerTarget) -> list[BoundAction]:
+    def remove_target(self, target: LoadBalancerTarget) -> BoundAction:
         """Removes a target from a Load Balancer.
 
         :param target: :class:`LoadBalancerTarget <hcloud.load_balancers.domain.LoadBalancerTarget>`
@@ -245,7 +245,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.remove_target(self, target)
 
-    def change_algorithm(self, algorithm: LoadBalancerAlgorithm) -> list[BoundAction]:
+    def change_algorithm(self, algorithm: LoadBalancerAlgorithm) -> BoundAction:
         """Changes the algorithm used by the Load Balancer
 
         :param algorithm: :class:`LoadBalancerAlgorithm <hcloud.load_balancers.domain.LoadBalancerAlgorithm>`
@@ -265,7 +265,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.change_dns_ptr(self, ip, dns_ptr)
 
-    def change_protection(self, delete: LoadBalancerService) -> list[BoundAction]:
+    def change_protection(self, delete: bool) -> BoundAction:
         """Changes the protection configuration of a Load Balancer.
 
         :param delete: boolean
@@ -362,7 +362,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if label_selector is not None:
@@ -397,7 +397,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector)
 
-    def get_by_name(self, name: str) -> BoundLoadBalancer:
+    def get_by_name(self, name: str) -> BoundLoadBalancer | None:
         """Get Load Balancer by name
 
         :param name: str
@@ -409,12 +409,12 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
     def create(
         self,
         name: str,
-        load_balancer_type: LoadBalancerType,
+        load_balancer_type: LoadBalancerType | BoundLoadBalancerType,
         algorithm: LoadBalancerAlgorithm | None = None,
         services: list[LoadBalancerService] | None = None,
         targets: list[LoadBalancerTarget] | None = None,
         labels: dict[str, str] | None = None,
-        location: Location | None = None,
+        location: Location | BoundLocation | None = None,
         network_zone: str | None = None,
         public_interface: bool | None = None,
         network: Network | BoundNetwork | None = None,
@@ -443,7 +443,10 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                 Adds the Load Balancer to a Network
         :return: :class:`CreateLoadBalancerResponse <hcloud.load_balancers.domain.CreateLoadBalancerResponse>`
         """
-        data = {"name": name, "load_balancer_type": load_balancer_type.id_or_name}
+        data: dict[str, Any] = {
+            "name": name,
+            "load_balancer_type": load_balancer_type.id_or_name,
+        }
         if network is not None:
             data["network"] = network.id
         if public_interface is not None:
@@ -491,7 +494,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        load_balancer: LoadBalancer,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
         name: str | None = None,
         labels: dict[str, str] | None = None,
     ) -> BoundLoadBalancer:
@@ -504,7 +507,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if name is not None:
             data.update({"name": name})
         if labels is not None:
@@ -518,7 +521,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundLoadBalancer(self, response["load_balancer"])
 
-    def delete(self, load_balancer: LoadBalancer) -> BoundAction:
+    def delete(self, load_balancer: LoadBalancer | BoundLoadBalancer) -> bool:
         """Deletes a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -534,7 +537,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        load_balancer: LoadBalancer,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
         status: list[str] | None = None,
         sort: list[str] | None = None,
         page: int | None = None,
@@ -553,7 +556,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if status is not None:
             params["status"] = status
         if sort is not None:
@@ -578,7 +581,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        load_balancer: LoadBalancer,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
         status: list[str] | None = None,
         sort: list[str] | None = None,
     ) -> list[BoundAction]:
@@ -597,7 +600,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         load_balancer: LoadBalancer | BoundLoadBalancer,
         service: LoadBalancerService,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Adds a service to a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -616,8 +619,8 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def get_service_parameters(self, service):
-        data = {}
+    def get_service_parameters(self, service: LoadBalancerService) -> dict[str, Any]:
+        data: dict[str, Any] = {}
         if service.protocol is not None:
             data["protocol"] = service.protocol
         if service.listen_port is not None:
@@ -685,7 +688,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         load_balancer: LoadBalancer | BoundLoadBalancer,
         service: LoadBalancerService,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Updates a service of an Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -707,7 +710,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         load_balancer: LoadBalancer | BoundLoadBalancer,
         service: LoadBalancerService,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Deletes a service from a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -715,7 +718,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                        The LoadBalancerService you want to delete from the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"listen_port": service.listen_port}
+        data: dict[str, Any] = {"listen_port": service.listen_port}
 
         response = self._client.request(
             url="/load_balancers/{load_balancer_id}/actions/delete_service".format(
@@ -730,7 +733,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         load_balancer: LoadBalancer | BoundLoadBalancer,
         target: LoadBalancerTarget,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Adds a target to a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -738,7 +741,10 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                        The LoadBalancerTarget you want to add to the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"type": target.type, "use_private_ip": target.use_private_ip}
+        data: dict[str, Any] = {
+            "type": target.type,
+            "use_private_ip": target.use_private_ip,
+        }
         if target.type == "server":
             data["server"] = {"id": target.server.id}
         elif target.type == "label_selector":
@@ -759,7 +765,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         load_balancer: LoadBalancer | BoundLoadBalancer,
         target: LoadBalancerTarget,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Removes a target from a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -767,7 +773,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                        The LoadBalancerTarget you want to remove from the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"type": target.type}
+        data: dict[str, Any] = {"type": target.type}
         if target.type == "server":
             data["server"] = {"id": target.server.id}
         elif target.type == "label_selector":
@@ -787,7 +793,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
     def change_algorithm(
         self,
         load_balancer: LoadBalancer | BoundLoadBalancer,
-        algorithm: bool | None,
+        algorithm: LoadBalancerAlgorithm,
     ) -> BoundAction:
         """Changes the algorithm used by the Load Balancer
 
@@ -796,7 +802,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                        The LoadBalancerSubnet you want to add to the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"type": algorithm.type}
+        data: dict[str, Any] = {"type": algorithm.type}
 
         response = self._client.request(
             url="/load_balancers/{load_balancer_id}/actions/change_algorithm".format(
@@ -843,7 +849,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                If True, prevents the Load Balancer from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if delete is not None:
             data.update({"delete": delete})
 
@@ -870,7 +876,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                 IP to request to be assigned to this Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"network": network.id}
+        data: dict[str, Any] = {"network": network.id}
         if ip is not None:
             data.update({"ip": ip})
 
@@ -894,7 +900,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"network": network.id}
+        data: dict[str, Any] = {"network": network.id}
         response = self._client.request(
             url="/load_balancers/{load_balancer_id}/actions/detach_from_network".format(
                 load_balancer_id=load_balancer.id
@@ -954,7 +960,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                Load Balancer type the Load Balancer should migrate to
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"load_balancer_type": load_balancer_type.id_or_name}
+        data: dict[str, Any] = {"load_balancer_type": load_balancer_type.id_or_name}
         response = self._client.request(
             url="/load_balancers/{load_balancer_id}/actions/change_type".format(
                 load_balancer_id=load_balancer.id

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -143,7 +143,9 @@ class BoundLoadBalancer(BoundModelBase):
         super().__init__(client, data, complete)
 
     def update(
-        self, name: str | None = None, labels: dict[str, str] | None = None
+        self,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> BoundLoadBalancer:
         """Updates a Load Balancer. You can update a Load Balancers name and a Load Balancers labels.
 
@@ -184,7 +186,9 @@ class BoundLoadBalancer(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a Load Balancer.
 
@@ -271,7 +275,9 @@ class BoundLoadBalancer(BoundModelBase):
         return self._client.change_protection(self, delete)
 
     def attach_to_network(
-        self, network: Network | BoundNetwork, ip: str | None = None
+        self,
+        network: Network | BoundNetwork,
+        ip: str | None = None,
     ) -> BoundAction:
         """Attaches a Load Balancer to a Network
 
@@ -305,7 +311,8 @@ class BoundLoadBalancer(BoundModelBase):
         return self._client.disable_public_interface(self)
 
     def change_type(
-        self, load_balancer_type: LoadBalancerType | BoundLoadBalancerType
+        self,
+        load_balancer_type: LoadBalancerType | BoundLoadBalancerType,
     ) -> BoundAction:
         """Changes the type of a Load Balancer.
 
@@ -376,7 +383,9 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         return LoadBalancersPageResult(load_balancers, Meta.parse_meta(response))
 
     def get_all(
-        self, name: str | None = None, label_selector: str | None = None
+        self,
+        name: str | None = None,
+        label_selector: str | None = None,
     ) -> list[BoundLoadBalancer]:
         """Get all Load Balancers from this account
 
@@ -896,7 +905,8 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def enable_public_interface(
-        self, load_balancer: LoadBalancer | BoundLoadBalancer
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
     ) -> BoundAction:
         """Enables the public interface of a Load Balancer.
 
@@ -914,7 +924,8 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def disable_public_interface(
-        self, load_balancer: LoadBalancer | BoundLoadBalancer
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
     ) -> BoundAction:
         """Disables the public interface of a Load Balancer.
 

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -28,6 +28,9 @@ from .domain import (
 
 if TYPE_CHECKING:
     from .._client import Client
+    from ..load_balancer_types import LoadBalancerType
+    from ..locations import Location
+    from ..networks import Network
 
 
 class BoundLoadBalancer(BoundModelBase):
@@ -139,8 +142,9 @@ class BoundLoadBalancer(BoundModelBase):
 
         super().__init__(client, data, complete)
 
-    def update(self, name=None, labels=None):
-        # type: (Optional[str], Optional[Dict[str, str]]) -> BoundLoadBalancer
+    def update(
+        self, name: str | None = None, labels: dict[str, str] | None = None
+    ) -> BoundLoadBalancer:
         """Updates a Load Balancer. You can update a Load Balancers name and a Load Balancers labels.
 
         :param name: str (optional)
@@ -151,16 +155,20 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.update(self, name, labels)
 
-    def delete(self):
-        # type: () -> BoundAction
+    def delete(self) -> BoundAction:
         """Deletes a Load Balancer.
 
         :return: boolean
         """
         return self._client.delete(self)
 
-    def get_actions_list(self, status=None, sort=None, page=None, per_page=None):
-        # type: (Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction, Meta]]
+    def get_actions_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Load Balancer.
 
         :param status: List[str] (optional)
@@ -175,8 +183,9 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
-    def get_actions(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for a Load Balancer.
 
         :param status: List[str] (optional)
@@ -187,8 +196,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def add_service(self, service):
-        # type: (LoadBalancerService) -> List[BoundAction]
+    def add_service(self, service: LoadBalancerService) -> list[BoundAction]:
         """Adds a service to a Load Balancer.
 
         :param service: :class:`LoadBalancerService <hcloud.load_balancers.domain.LoadBalancerService>`
@@ -197,8 +205,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.add_service(self, service=service)
 
-    def update_service(self, service):
-        # type: (LoadBalancerService) -> List[BoundAction]
+    def update_service(self, service: LoadBalancerService) -> list[BoundAction]:
         """Updates a service of an Load Balancer.
 
         :param service: :class:`LoadBalancerService <hcloud.load_balancers.domain.LoadBalancerService>`
@@ -207,8 +214,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.update_service(self, service=service)
 
-    def delete_service(self, service):
-        # type: (LoadBalancerService) -> List[BoundAction]
+    def delete_service(self, service: LoadBalancerService) -> list[BoundAction]:
         """Deletes a service from a Load Balancer.
 
         :param service: :class:`LoadBalancerService <hcloud.load_balancers.domain.LoadBalancerService>`
@@ -217,8 +223,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.delete_service(self, service)
 
-    def add_target(self, target):
-        # type: (LoadBalancerTarget) -> List[BoundAction]
+    def add_target(self, target: LoadBalancerTarget) -> list[BoundAction]:
         """Adds a target to a Load Balancer.
 
         :param target: :class:`LoadBalancerTarget <hcloud.load_balancers.domain.LoadBalancerTarget>`
@@ -227,8 +232,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.add_target(self, target)
 
-    def remove_target(self, target):
-        # type: (LoadBalancerTarget) -> List[BoundAction]
+    def remove_target(self, target: LoadBalancerTarget) -> list[BoundAction]:
         """Removes a target from a Load Balancer.
 
         :param target: :class:`LoadBalancerTarget <hcloud.load_balancers.domain.LoadBalancerTarget>`
@@ -237,8 +241,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.remove_target(self, target)
 
-    def change_algorithm(self, algorithm):
-        # type: (LoadBalancerAlgorithm) -> List[BoundAction]
+    def change_algorithm(self, algorithm: LoadBalancerAlgorithm) -> list[BoundAction]:
         """Changes the algorithm used by the Load Balancer
 
         :param algorithm: :class:`LoadBalancerAlgorithm <hcloud.load_balancers.domain.LoadBalancerAlgorithm>`
@@ -247,8 +250,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.change_algorithm(self, algorithm)
 
-    def change_dns_ptr(self, ip, dns_ptr):
-        # type: (str, str) -> BoundAction
+    def change_dns_ptr(self, ip: str, dns_ptr: str) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to the public IPs (IPv4 and IPv6) of this Load Balancer.
 
         :param ip: str
@@ -259,8 +261,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.change_dns_ptr(self, ip, dns_ptr)
 
-    def change_protection(self, delete):
-        # type: (LoadBalancerService) -> List[BoundAction]
+    def change_protection(self, delete: LoadBalancerService) -> list[BoundAction]:
         """Changes the protection configuration of a Load Balancer.
 
         :param delete: boolean
@@ -269,8 +270,9 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.change_protection(self, delete)
 
-    def attach_to_network(self, network, ip=None):
-        # type: (Union[Network,BoundNetwork],Optional[str]) -> BoundAction
+    def attach_to_network(
+        self, network: Network | BoundNetwork, ip: str | None = None
+    ) -> BoundAction:
         """Attaches a Load Balancer to a Network
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -280,8 +282,7 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.attach_to_network(self, network, ip)
 
-    def detach_from_network(self, network):
-        # type: ( Union[Network,BoundNetwork]) -> BoundAction
+    def detach_from_network(self, network: Network | BoundNetwork) -> BoundAction:
         """Detaches a Load Balancer from a Network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -289,24 +290,23 @@ class BoundLoadBalancer(BoundModelBase):
         """
         return self._client.detach_from_network(self, network)
 
-    def enable_public_interface(self):
-        # type: () -> BoundAction
+    def enable_public_interface(self) -> BoundAction:
         """Enables the public interface of a Load Balancer.
 
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.enable_public_interface(self)
 
-    def disable_public_interface(self):
-        # type: () -> BoundAction
+    def disable_public_interface(self) -> BoundAction:
         """Disables the public interface of a Load Balancer.
 
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.disable_public_interface(self)
 
-    def change_type(self, load_balancer_type):
-        # type: (Union[LoadBalancerType,BoundLoadBalancerType]) -> BoundAction
+    def change_type(
+        self, load_balancer_type: LoadBalancerType | BoundLoadBalancerType
+    ) -> BoundAction:
         """Changes the type of a Load Balancer.
 
         :param load_balancer_type: :class:`BoundLoadBalancerType <hcloud.load_balancer_types.client.BoundLoadBalancerType>` or :class:`LoadBalancerType <hcloud.load_balancer_types.domain.LoadBalancerType>`
@@ -324,8 +324,7 @@ class LoadBalancersPageResult(NamedTuple):
 class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundLoadBalancer
+    def get_by_id(self, id: int) -> BoundLoadBalancer:
         """Get a specific Load Balancer
 
         :param id: int
@@ -339,12 +338,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundLoadBalancer], Meta]
+        name: str | None = None,
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> LoadBalancersPageResult:
         """Get a list of Load Balancers from this account
 
         :param name: str (optional)
@@ -377,8 +375,9 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return LoadBalancersPageResult(load_balancers, Meta.parse_meta(response))
 
-    def get_all(self, name=None, label_selector=None):
-        # type: (Optional[str], Optional[str]) -> List[BoundLoadBalancer]
+    def get_all(
+        self, name: str | None = None, label_selector: str | None = None
+    ) -> list[BoundLoadBalancer]:
         """Get all Load Balancers from this account
 
         :param name: str (optional)
@@ -389,8 +388,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundLoadBalancer
+    def get_by_name(self, name: str) -> BoundLoadBalancer:
         """Get Load Balancer by name
 
         :param name: str
@@ -401,18 +399,17 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        name,  # type: str
-        load_balancer_type,  # type: LoadBalancerType
-        algorithm=None,  # type: Optional[LoadBalancerAlgorithm]
-        services=None,  # type:  Optional[List[LoadBalancerService]]
-        targets=None,  # type:  Optional[List[LoadBalancerTarget]]
-        labels=None,  # type: Optional[Dict[str, str]]
-        location=None,  # type: Optional[Location]
-        network_zone=None,  # type: Optional[str]
-        public_interface=None,  # type: Optional[bool]
-        network=None,  # type: Optional[Union[Network,BoundNetwork]]
-    ):
-        # type: (...) -> CreateLoadBalancerResponse
+        name: str,
+        load_balancer_type: LoadBalancerType,
+        algorithm: LoadBalancerAlgorithm | None = None,
+        services: list[LoadBalancerService] | None = None,
+        targets: list[LoadBalancerTarget] | None = None,
+        labels: dict[str, str] | None = None,
+        location: Location | None = None,
+        network_zone: str | None = None,
+        public_interface: bool | None = None,
+        network: Network | BoundNetwork | None = None,
+    ) -> CreateLoadBalancerResponse:
         """Creates a Load Balancer .
 
         :param name: str
@@ -483,8 +480,12 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
             action=BoundAction(self._client.actions, response["action"]),
         )
 
-    def update(self, load_balancer, name=None, labels=None):
-        # type:(LoadBalancer,  Optional[str],  Optional[Dict[str, str]]) -> BoundLoadBalancer
+    def update(
+        self,
+        load_balancer: LoadBalancer,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundLoadBalancer:
         """Updates a LoadBalancer. You can update a LoadBalancer’s name and a LoadBalancer’s labels.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -508,8 +509,7 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundLoadBalancer(self, response["load_balancer"])
 
-    def delete(self, load_balancer):
-        # type: (LoadBalancer) -> BoundAction
+    def delete(self, load_balancer: LoadBalancer) -> BoundAction:
         """Deletes a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -524,9 +524,13 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def get_actions_list(
-        self, load_balancer, status=None, sort=None, page=None, per_page=None
-    ):
-        # type: (LoadBalancer, Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction], Meta]
+        self,
+        load_balancer: LoadBalancer,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -563,8 +567,12 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return ActionsPageResult(actions, Meta.parse_meta(response))
 
-    def get_actions(self, load_balancer, status=None, sort=None):
-        # type: (LoadBalancer, Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self,
+        load_balancer: LoadBalancer,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -576,8 +584,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(load_balancer, status=status, sort=sort)
 
-    def add_service(self, load_balancer, service):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], LoadBalancerService) -> List[BoundAction]
+    def add_service(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        service: LoadBalancerService,
+    ) -> list[BoundAction]:
         """Adds a service to a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -661,8 +672,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
                     data["health_check"]["http"]["tls"] = service.health_check.http.tls
         return data
 
-    def update_service(self, load_balancer, service):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], LoadBalancerService) -> List[BoundAction]
+    def update_service(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        service: LoadBalancerService,
+    ) -> list[BoundAction]:
         """Updates a service of an Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -680,8 +694,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def delete_service(self, load_balancer, service):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], LoadBalancerService) -> List[BoundAction]
+    def delete_service(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        service: LoadBalancerService,
+    ) -> list[BoundAction]:
         """Deletes a service from a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -700,8 +717,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def add_target(self, load_balancer, target):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], LoadBalancerTarget) -> List[BoundAction]
+    def add_target(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        target: LoadBalancerTarget,
+    ) -> list[BoundAction]:
         """Adds a target to a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -726,8 +746,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def remove_target(self, load_balancer, target):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], LoadBalancerTarget) -> List[BoundAction]
+    def remove_target(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        target: LoadBalancerTarget,
+    ) -> list[BoundAction]:
         """Removes a target from a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -752,8 +775,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_algorithm(self, load_balancer, algorithm):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], Optional[bool]) -> BoundAction
+    def change_algorithm(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        algorithm: bool | None,
+    ) -> BoundAction:
         """Changes the algorithm used by the Load Balancer
 
         :param load_balancer: :class:` <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -772,8 +798,12 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_dns_ptr(self, load_balancer, ip, dns_ptr):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], str, str) -> BoundAction
+    def change_dns_ptr(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        ip: str,
+        dns_ptr: str,
+    ) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to the public IPs (IPv4 and IPv6) of this Load Balancer.
 
         :param ip: str
@@ -792,8 +822,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_protection(self, load_balancer, delete=None):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], Optional[bool]) -> BoundAction
+    def change_protection(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        delete: bool | None = None,
+    ) -> BoundAction:
         """Changes the protection configuration of a Load Balancer.
 
         :param load_balancer: :class:` <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -816,9 +849,9 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def attach_to_network(
         self,
-        load_balancer,  # type: Union[LoadBalancer, BoundLoadBalancer]
-        network,  # type: Union[Network, BoundNetwork]
-        ip=None,  # type: Optional[str]
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        network: Network | BoundNetwork,
+        ip: str | None = None,
     ):
         """Attach a Load Balancer to a Network.
 
@@ -841,8 +874,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def detach_from_network(self, load_balancer, network):
-        # type: (Union[LoadBalancer, BoundLoadBalancer], Union[Network,BoundNetwork]) -> BoundAction
+    def detach_from_network(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        network: Network | BoundNetwork,
+    ) -> BoundAction:
         """Detaches a Load Balancer from a Network.
 
         :param load_balancer: :class:` <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -859,8 +895,9 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def enable_public_interface(self, load_balancer):
-        # type: (Union[LoadBalancer, BoundLoadBalancer]) -> BoundAction
+    def enable_public_interface(
+        self, load_balancer: LoadBalancer | BoundLoadBalancer
+    ) -> BoundAction:
         """Enables the public interface of a Load Balancer.
 
         :param load_balancer: :class:` <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -876,8 +913,9 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def disable_public_interface(self, load_balancer):
-        # type: (Union[LoadBalancer, BoundLoadBalancer]) -> BoundAction
+    def disable_public_interface(
+        self, load_balancer: LoadBalancer | BoundLoadBalancer
+    ) -> BoundAction:
         """Disables the public interface of a Load Balancer.
 
         :param load_balancer: :class:` <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`
@@ -893,8 +931,11 @@ class LoadBalancersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_type(self, load_balancer, load_balancer_type):
-        # type: ([LoadBalancer, BoundLoadBalancer], [LoadBalancerType, BoundLoadBalancerType]) ->BoundAction
+    def change_type(
+        self,
+        load_balancer: LoadBalancer | BoundLoadBalancer,
+        load_balancer_type: LoadBalancerType | BoundLoadBalancerType,
+    ) -> BoundAction:
         """Changes the type of a Load Balancer.
 
         :param load_balancer: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>` or :class:`LoadBalancer <hcloud.load_balancers.domain.LoadBalancer>`

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -214,7 +214,12 @@ class LoadBalancerHealtCheckHttp(BaseDomain):
     """
 
     def __init__(
-        self, domain=None, path=None, response=None, status_codes=None, tls=None
+        self,
+        domain=None,
+        path=None,
+        response=None,
+        status_codes=None,
+        tls=None,
     ):
         self.domain = domain
         self.path = path
@@ -239,7 +244,12 @@ class LoadBalancerTarget(BaseDomain):
     """
 
     def __init__(
-        self, type=None, server=None, label_selector=None, ip=None, use_private_ip=None
+        self,
+        type=None,
+        server=None,
+        label_selector=None,
+        ip=None,
+        use_private_ip=None,
     ):
         self.type = type
         self.server = server

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from ..networks import BoundNetwork
+    from .client import BoundLoadBalancer
 
 
 class LoadBalancer(BaseDomain):
@@ -284,9 +291,9 @@ class PublicNetwork(BaseDomain):
 
     def __init__(
         self,
-        ipv4,  # type: IPv4Address
-        ipv6,  # type: IPv6Network
-        enabled,  # type: bool
+        ipv4: IPv4Address,
+        ipv6: IPv6Network,
+        enabled: bool,
     ):
         self.ipv4 = ipv4
         self.ipv6 = ipv6
@@ -304,8 +311,8 @@ class IPv4Address(BaseDomain):
 
     def __init__(
         self,
-        ip,  # type: str
-        dns_ptr,  # type: str
+        ip: str,
+        dns_ptr: str,
     ):
         self.ip = ip
         self.dns_ptr = dns_ptr
@@ -322,8 +329,8 @@ class IPv6Network(BaseDomain):
 
     def __init__(
         self,
-        ip,  # type: str
-        dns_ptr,  # type: str
+        ip: str,
+        dns_ptr: str,
     ):
         self.ip = ip
         self.dns_ptr = dns_ptr
@@ -342,8 +349,8 @@ class PrivateNet(BaseDomain):
 
     def __init__(
         self,
-        network,  # type: BoundNetwork
-        ip,  # type: str
+        network: BoundNetwork,
+        ip: str,
     ):
         self.network = network
         self.ip = ip
@@ -362,8 +369,8 @@ class CreateLoadBalancerResponse(BaseDomain):
 
     def __init__(
         self,
-        load_balancer,  # type: BoundLoadBalancer
-        action,  # type: BoundAction
+        load_balancer: BoundLoadBalancer,
+        action: BoundAction,
     ):
         self.load_balancer = load_balancer
         self.action = action

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import Location
@@ -48,7 +48,7 @@ class LocationsClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundLocation <hcloud.locations.client.BoundLocation>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if page is not None:
@@ -72,7 +72,7 @@ class LocationsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name: str) -> BoundLocation:
+    def get_by_name(self, name: str) -> BoundLocation | None:
         """Get location by name
 
         :param name: str

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -23,8 +23,7 @@ class LocationsPageResult(NamedTuple):
 class LocationsClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> locations.client.BoundLocation
+    def get_by_id(self, id: int) -> BoundLocation:
         """Get a specific location by its ID.
 
         :param id: int
@@ -33,8 +32,12 @@ class LocationsClient(ClientEntityBase, GetEntityByNameMixin):
         response = self._client.request(url=f"/locations/{id}", method="GET")
         return BoundLocation(self, response["location"])
 
-    def get_list(self, name=None, page=None, per_page=None):
-        # type: (Optional[str], Optional[int], Optional[int]) -> PageResult[List[BoundLocation], Meta]
+    def get_list(
+        self,
+        name: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> LocationsPageResult:
         """Get a list of locations
 
         :param name: str (optional)
@@ -60,8 +63,7 @@ class LocationsClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return LocationsPageResult(locations, Meta.parse_meta(response))
 
-    def get_all(self, name=None):
-        # type: (Optional[str]) -> List[BoundLocation]
+    def get_all(self, name: str | None = None) -> list[BoundLocation]:
         """Get all locations
 
         :param name: str (optional)
@@ -70,8 +72,7 @@ class LocationsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundLocation
+    def get_by_name(self, name: str) -> BoundLocation:
         """Get location by name
 
         :param name: str

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -15,7 +15,7 @@ class BoundNetwork(BoundModelBase):
 
     model = Network
 
-    def __init__(self, client, data, complete=True):
+    def __init__(self, client: NetworksClient, data: dict, complete: bool = True):
         subnets = data.get("subnets", [])
         if subnets is not None:
             subnets = [NetworkSubnet.from_dict(subnet) for subnet in subnets]
@@ -62,7 +62,7 @@ class BoundNetwork(BoundModelBase):
             labels=labels,
         )
 
-    def delete(self) -> BoundAction:
+    def delete(self) -> bool:
         """Deletes a network.
 
         :return: boolean
@@ -105,7 +105,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def add_subnet(self, subnet: NetworkSubnet) -> list[BoundAction]:
+    def add_subnet(self, subnet: NetworkSubnet) -> BoundAction:
         """Adds a subnet entry to a network.
 
         :param subnet: :class:`NetworkSubnet <hcloud.networks.domain.NetworkSubnet>`
@@ -114,7 +114,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.add_subnet(self, subnet=subnet)
 
-    def delete_subnet(self, subnet: NetworkSubnet) -> list[BoundAction]:
+    def delete_subnet(self, subnet: NetworkSubnet) -> BoundAction:
         """Removes a subnet entry from a network
 
         :param subnet: :class:`NetworkSubnet <hcloud.networks.domain.NetworkSubnet>`
@@ -123,7 +123,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.delete_subnet(self, subnet=subnet)
 
-    def add_route(self, route: NetworkRoute) -> list[BoundAction]:
+    def add_route(self, route: NetworkRoute) -> BoundAction:
         """Adds a route entry to a network.
 
         :param route: :class:`NetworkRoute <hcloud.networks.domain.NetworkRoute>`
@@ -132,7 +132,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.add_route(self, route=route)
 
-    def delete_route(self, route: NetworkRoute) -> list[BoundAction]:
+    def delete_route(self, route: NetworkRoute) -> BoundAction:
         """Removes a route entry to a network.
 
         :param route: :class:`NetworkRoute <hcloud.networks.domain.NetworkRoute>`
@@ -141,7 +141,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.delete_route(self, route=route)
 
-    def change_ip_range(self, ip_range: str) -> list[BoundAction]:
+    def change_ip_range(self, ip_range: str) -> BoundAction:
         """Changes the IP range of a network.
 
         :param ip_range: str
@@ -196,7 +196,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundNetwork <hcloud.networks.client.BoundNetwork>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if label_selector is not None:
@@ -228,7 +228,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector)
 
-    def get_by_name(self, name: str) -> BoundNetwork:
+    def get_by_name(self, name: str) -> BoundNetwork | None:
         """Get network by name
 
         :param name: str
@@ -263,7 +263,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                 User-defined labels (key-value pairs)
         :return: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>`
         """
-        data = {"name": name, "ip_range": ip_range}
+        data: dict[str, Any] = {"name": name, "ip_range": ip_range}
         if subnets is not None:
             data_subnets = []
             for subnet in subnets:
@@ -296,7 +296,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        network: Network,
+        network: Network | BoundNetwork,
         name: str | None = None,
         expose_routes_to_vswitch: bool | None = None,
         labels: dict[str, str] | None = None,
@@ -313,7 +313,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if name is not None:
             data.update({"name": name})
 
@@ -330,7 +330,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundNetwork(self, response["network"])
 
-    def delete(self, network: Network) -> BoundAction:
+    def delete(self, network: Network | BoundNetwork) -> bool:
         """Deletes a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -341,7 +341,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        network: Network,
+        network: Network | BoundNetwork,
         status: list[str] | None = None,
         sort: list[str] | None = None,
         page: int | None = None,
@@ -360,7 +360,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if status is not None:
             params["status"] = status
         if sort is not None:
@@ -383,7 +383,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions(
         self,
-        network: Network,
+        network: Network | BoundNetwork,
         status: list[str] | None = None,
         sort: list[str] | None = None,
     ) -> list[BoundAction]:
@@ -402,7 +402,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         network: Network | BoundNetwork,
         subnet: NetworkSubnet,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Adds a subnet entry to a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -410,7 +410,10 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                        The NetworkSubnet you want to add to the Network
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"type": subnet.type, "network_zone": subnet.network_zone}
+        data: dict[str, Any] = {
+            "type": subnet.type,
+            "network_zone": subnet.network_zone,
+        }
         if subnet.ip_range is not None:
             data["ip_range"] = subnet.ip_range
         if subnet.vswitch_id is not None:
@@ -429,7 +432,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         network: Network | BoundNetwork,
         subnet: NetworkSubnet,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Removes a subnet entry from a network
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -437,7 +440,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                        The NetworkSubnet you want to remove from the Network
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"ip_range": subnet.ip_range}
+        data: dict[str, Any] = {"ip_range": subnet.ip_range}
 
         response = self._client.request(
             url="/networks/{network_id}/actions/delete_subnet".format(
@@ -452,7 +455,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         network: Network | BoundNetwork,
         route: NetworkRoute,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Adds a route entry to a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -460,7 +463,10 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                     The NetworkRoute you want to add to the Network
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"destination": route.destination, "gateway": route.gateway}
+        data: dict[str, Any] = {
+            "destination": route.destination,
+            "gateway": route.gateway,
+        }
 
         response = self._client.request(
             url="/networks/{network_id}/actions/add_route".format(
@@ -475,7 +481,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         network: Network | BoundNetwork,
         route: NetworkRoute,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Removes a route entry to a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -483,7 +489,10 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                     The NetworkRoute you want to remove from the Network
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"destination": route.destination, "gateway": route.gateway}
+        data: dict[str, Any] = {
+            "destination": route.destination,
+            "gateway": route.gateway,
+        }
 
         response = self._client.request(
             url="/networks/{network_id}/actions/delete_route".format(
@@ -498,7 +507,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         self,
         network: Network | BoundNetwork,
         ip_range: str,
-    ) -> list[BoundAction]:
+    ) -> BoundAction:
         """Changes the IP range of a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -506,7 +515,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                     The new prefix for the whole network.
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"ip_range": ip_range}
+        data: dict[str, Any] = {"ip_range": ip_range}
 
         response = self._client.request(
             url="/networks/{network_id}/actions/change_ip_range".format(
@@ -529,7 +538,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
                If True, prevents the network from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if delete is not None:
             data.update({"delete": delete})
 

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -91,7 +91,9 @@ class BoundNetwork(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a network.
 
@@ -212,7 +214,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return NetworksPageResult(networks, Meta.parse_meta(response))
 
     def get_all(
-        self, name: str | None = None, label_selector: str | None = None
+        self,
+        name: str | None = None,
+        label_selector: str | None = None,
     ) -> list[BoundNetwork]:
         """Get all networks from this account
 
@@ -395,7 +399,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return super().get_actions(network, status=status, sort=sort)
 
     def add_subnet(
-        self, network: Network | BoundNetwork, subnet: NetworkSubnet
+        self,
+        network: Network | BoundNetwork,
+        subnet: NetworkSubnet,
     ) -> list[BoundAction]:
         """Adds a subnet entry to a network.
 
@@ -420,7 +426,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def delete_subnet(
-        self, network: Network | BoundNetwork, subnet: NetworkSubnet
+        self,
+        network: Network | BoundNetwork,
+        subnet: NetworkSubnet,
     ) -> list[BoundAction]:
         """Removes a subnet entry from a network
 
@@ -441,7 +449,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def add_route(
-        self, network: Network | BoundNetwork, route: NetworkRoute
+        self,
+        network: Network | BoundNetwork,
+        route: NetworkRoute,
     ) -> list[BoundAction]:
         """Adds a route entry to a network.
 
@@ -462,7 +472,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def delete_route(
-        self, network: Network | BoundNetwork, route: NetworkRoute
+        self,
+        network: Network | BoundNetwork,
+        route: NetworkRoute,
     ) -> list[BoundAction]:
         """Removes a route entry to a network.
 
@@ -483,7 +495,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def change_ip_range(
-        self, network: Network | BoundNetwork, ip_range: str
+        self,
+        network: Network | BoundNetwork,
+        ip_range: str,
     ) -> list[BoundAction]:
         """Changes the IP range of a network.
 
@@ -504,7 +518,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def change_protection(
-        self, network: Network | BoundNetwork, delete: bool | None = None
+        self,
+        network: Network | BoundNetwork,
+        delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of a network.
 

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -40,10 +40,10 @@ class BoundNetwork(BoundModelBase):
 
     def update(
         self,
-        name=None,  # type: Optional[str]
-        expose_routes_to_vswitch=None,  # type: Optional[bool]
-        labels=None,  # type: Optional[Dict[str, str]]
-    ):  # type: (...) -> BoundNetwork
+        name: str | None = None,
+        expose_routes_to_vswitch: bool | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundNetwork:
         """Updates a network. You can update a network’s name and a networks’s labels.
 
         :param name: str (optional)
@@ -62,16 +62,20 @@ class BoundNetwork(BoundModelBase):
             labels=labels,
         )
 
-    def delete(self):
-        # type: () -> BoundAction
+    def delete(self) -> BoundAction:
         """Deletes a network.
 
         :return: boolean
         """
         return self._client.delete(self)
 
-    def get_actions_list(self, status=None, sort=None, page=None, per_page=None):
-        # type: (Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction, Meta]]
+    def get_actions_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a network.
 
         :param status: List[str] (optional)
@@ -86,8 +90,9 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
-    def get_actions(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for a network.
 
         :param status: List[str] (optional)
@@ -98,8 +103,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def add_subnet(self, subnet):
-        # type: (NetworkSubnet) -> List[BoundAction]
+    def add_subnet(self, subnet: NetworkSubnet) -> list[BoundAction]:
         """Adds a subnet entry to a network.
 
         :param subnet: :class:`NetworkSubnet <hcloud.networks.domain.NetworkSubnet>`
@@ -108,8 +112,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.add_subnet(self, subnet=subnet)
 
-    def delete_subnet(self, subnet):
-        # type: (NetworkSubnet) -> List[BoundAction]
+    def delete_subnet(self, subnet: NetworkSubnet) -> list[BoundAction]:
         """Removes a subnet entry from a network
 
         :param subnet: :class:`NetworkSubnet <hcloud.networks.domain.NetworkSubnet>`
@@ -118,8 +121,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.delete_subnet(self, subnet=subnet)
 
-    def add_route(self, route):
-        # type: (NetworkRoute) -> List[BoundAction]
+    def add_route(self, route: NetworkRoute) -> list[BoundAction]:
         """Adds a route entry to a network.
 
         :param route: :class:`NetworkRoute <hcloud.networks.domain.NetworkRoute>`
@@ -128,8 +130,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.add_route(self, route=route)
 
-    def delete_route(self, route):
-        # type: (NetworkRoute) -> List[BoundAction]
+    def delete_route(self, route: NetworkRoute) -> list[BoundAction]:
         """Removes a route entry to a network.
 
         :param route: :class:`NetworkRoute <hcloud.networks.domain.NetworkRoute>`
@@ -138,8 +139,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.delete_route(self, route=route)
 
-    def change_ip_range(self, ip_range):
-        # type: (str) -> List[BoundAction]
+    def change_ip_range(self, ip_range: str) -> list[BoundAction]:
         """Changes the IP range of a network.
 
         :param ip_range: str
@@ -148,8 +148,7 @@ class BoundNetwork(BoundModelBase):
         """
         return self._client.change_ip_range(self, ip_range=ip_range)
 
-    def change_protection(self, delete=None):
-        # type: (Optional[bool]) -> BoundAction
+    def change_protection(self, delete: bool | None = None) -> BoundAction:
         """Changes the protection configuration of a network.
 
         :param delete: boolean
@@ -167,8 +166,7 @@ class NetworksPageResult(NamedTuple):
 class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundNetwork
+    def get_by_id(self, id: int) -> BoundNetwork:
         """Get a specific network
 
         :param id: int
@@ -179,12 +177,11 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundNetwork], Meta]
+        name: str | None = None,
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> NetworksPageResult:
         """Get a list of networks from this account
 
         :param name: str (optional)
@@ -214,8 +211,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return NetworksPageResult(networks, Meta.parse_meta(response))
 
-    def get_all(self, name=None, label_selector=None):
-        # type: (Optional[str], Optional[str]) -> List[BoundNetwork]
+    def get_all(
+        self, name: str | None = None, label_selector: str | None = None
+    ) -> list[BoundNetwork]:
         """Get all networks from this account
 
         :param name: str (optional)
@@ -226,8 +224,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundNetwork
+    def get_by_name(self, name: str) -> BoundNetwork:
         """Get network by name
 
         :param name: str
@@ -238,12 +235,12 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        name,  # type: str
-        ip_range,  # type: str
-        subnets=None,  # type: Optional[List[NetworkSubnet]]
-        routes=None,  # type:  Optional[List[NetworkRoute]]
-        expose_routes_to_vswitch=None,  # type: Optional[bool]
-        labels=None,  # type:  Optional[Dict[str, str]]
+        name: str,
+        ip_range: str,
+        subnets: list[NetworkSubnet] | None = None,
+        routes: list[NetworkRoute] | None = None,
+        expose_routes_to_vswitch: bool | None = None,
+        labels: dict[str, str] | None = None,
     ):
         """Creates a network with range ip_range.
 
@@ -293,8 +290,13 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
 
         return BoundNetwork(self, response["network"])
 
-    def update(self, network, name=None, expose_routes_to_vswitch=None, labels=None):
-        # type:(Network,  Optional[str], Optional[bool], Optional[Dict[str, str]]) -> BoundNetwork
+    def update(
+        self,
+        network: Network,
+        name: str | None = None,
+        expose_routes_to_vswitch: bool | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundNetwork:
         """Updates a network. You can update a network’s name and a network’s labels.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -324,8 +326,7 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundNetwork(self, response["network"])
 
-    def delete(self, network):
-        # type: (Network) -> BoundAction
+    def delete(self, network: Network) -> BoundAction:
         """Deletes a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -335,9 +336,13 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def get_actions_list(
-        self, network, status=None, sort=None, page=None, per_page=None
-    ):
-        # type: (Network, Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction], Meta]
+        self,
+        network: Network,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -372,8 +377,12 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return ActionsPageResult(actions, Meta.parse_meta(response))
 
-    def get_actions(self, network, status=None, sort=None):
-        # type: (Network, Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self,
+        network: Network,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -385,8 +394,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(network, status=status, sort=sort)
 
-    def add_subnet(self, network, subnet):
-        # type: (Union[Network, BoundNetwork], NetworkSubnet) -> List[BoundAction]
+    def add_subnet(
+        self, network: Network | BoundNetwork, subnet: NetworkSubnet
+    ) -> list[BoundAction]:
         """Adds a subnet entry to a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -409,8 +419,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def delete_subnet(self, network, subnet):
-        # type: (Union[Network, BoundNetwork], NetworkSubnet) -> List[BoundAction]
+    def delete_subnet(
+        self, network: Network | BoundNetwork, subnet: NetworkSubnet
+    ) -> list[BoundAction]:
         """Removes a subnet entry from a network
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -429,8 +440,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def add_route(self, network, route):
-        # type: (Union[Network, BoundNetwork], NetworkRoute) -> List[BoundAction]
+    def add_route(
+        self, network: Network | BoundNetwork, route: NetworkRoute
+    ) -> list[BoundAction]:
         """Adds a route entry to a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -449,8 +461,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def delete_route(self, network, route):
-        # type: (Union[Network, BoundNetwork], NetworkRoute) -> List[BoundAction]
+    def delete_route(
+        self, network: Network | BoundNetwork, route: NetworkRoute
+    ) -> list[BoundAction]:
         """Removes a route entry to a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -469,8 +482,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_ip_range(self, network, ip_range):
-        # type: (Union[Network, BoundNetwork], str) -> List[BoundAction]
+    def change_ip_range(
+        self, network: Network | BoundNetwork, ip_range: str
+    ) -> list[BoundAction]:
         """Changes the IP range of a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -489,8 +503,9 @@ class NetworksClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_protection(self, network, delete=None):
-        # type: (Union[Network, BoundNetwork], Optional[bool]) -> BoundAction
+    def change_protection(
+        self, network: Network | BoundNetwork, delete: bool | None = None
+    ) -> BoundAction:
         """Changes the protection configuration of a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundNetwork
 
 
 class Network(BaseDomain):
@@ -128,8 +134,8 @@ class CreateNetworkResponse(BaseDomain):
 
     def __init__(
         self,
-        network,  # type: BoundNetwork
-        action,  # type: BoundAction
+        network: BoundNetwork,
+        action: BoundAction,
     ):
         self.network = network
         self.action = action

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -96,7 +96,12 @@ class NetworkSubnet(BaseDomain):
     __slots__ = ("type", "ip_range", "network_zone", "gateway", "vswitch_id")
 
     def __init__(
-        self, ip_range, type=None, network_zone=None, gateway=None, vswitch_id=None
+        self,
+        ip_range,
+        type=None,
+        network_zone=None,
+        gateway=None,
+        vswitch_id=None,
     ):
         self.type = type
         self.ip_range = ip_range

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -16,7 +16,7 @@ class BoundPlacementGroup(BoundModelBase):
     model = PlacementGroup
 
     def update(
-        self: str | None,
+        self,
         labels: dict[str, str] | None = None,
         name: str | None = None,
     ) -> BoundPlacementGroup:
@@ -82,7 +82,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         :return: (List[:class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
 
-        params = {}
+        params: dict[str, Any] = {}
 
         if label_selector is not None:
             params["label_selector"] = label_selector
@@ -124,7 +124,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name, sort=sort)
 
-    def get_by_name(self, name: str) -> BoundPlacementGroup:
+    def get_by_name(self, name: str) -> BoundPlacementGroup | None:
         """Get Placement Group by name
 
         :param name: str
@@ -150,7 +150,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
 
         :return: :class:`CreatePlacementGroupResponse <hcloud.placement_groups.domain.CreatePlacementGroupResponse>`
         """
-        data = {"name": name, "type": type}
+        data: dict[str, Any] = {"name": name, "type": type}
         if labels is not None:
             data["labels"] = labels
         response = self._client.request(
@@ -169,7 +169,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        placement_group: PlacementGroup,
+        placement_group: PlacementGroup | BoundPlacementGroup,
         labels: dict[str, str] | None = None,
         name: str | None = None,
     ) -> BoundPlacementGroup:
@@ -183,7 +183,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         :return: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>`
         """
 
-        data = {}
+        data: dict[str, Any] = {}
         if labels is not None:
             data["labels"] = labels
         if name is not None:
@@ -198,7 +198,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundPlacementGroup(self, response["placement_group"])
 
-    def delete(self, placement_group: PlacementGroup) -> bool:
+    def delete(self, placement_group: PlacementGroup | BoundPlacementGroup) -> bool:
         """Deletes a Placement Group.
 
         :param placement_group: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>` or :class:`PlacementGroup <hcloud.placement_groups.domain.PlacementGroup>`

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -15,8 +15,11 @@ class BoundPlacementGroup(BoundModelBase):
 
     model = PlacementGroup
 
-    def update(self, labels=None, name=None):
-        # type: (Optional[str], Optional[Dict[str, str]], Optional[str]) -> BoundPlacementGroup
+    def update(
+        self: str | None,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundPlacementGroup:
         """Updates the name or labels of a Placement Group
 
         :param labels: Dict[str, str] (optional)
@@ -27,8 +30,7 @@ class BoundPlacementGroup(BoundModelBase):
         """
         return self._client.update(self, labels, name)
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes a Placement Group
 
         :return: boolean
@@ -44,8 +46,7 @@ class PlacementGroupsPageResult(NamedTuple):
 class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundPlacementGroup
+    def get_by_id(self, id: int) -> BoundPlacementGroup:
         """Returns a specific Placement Group object
 
         :param id: int
@@ -59,14 +60,13 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        name=None,  # type: Optional[str]
-        sort=None,  # type: Optional[List[str]]
-        type=None,  # type: Optional[str]
-    ):
-        # type: (...) -> PageResults[List[BoundPlacementGroup]]
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        name: str | None = None,
+        sort: list[str] | None = None,
+        type: str | None = None,
+    ) -> PlacementGroupsPageResult:
         """Get a list of Placement Groups
 
         :param label_selector: str (optional)
@@ -106,8 +106,12 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
 
         return PlacementGroupsPageResult(placement_groups, Meta.parse_meta(response))
 
-    def get_all(self, label_selector=None, name=None, sort=None):
-        # type: (Optional[str], Optional[str],  Optional[List[str]]) -> List[BoundPlacementGroup]
+    def get_all(
+        self,
+        label_selector: str | None = None,
+        name: str | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundPlacementGroup]:
         """Get all Placement Groups
 
         :param label_selector: str (optional)
@@ -120,8 +124,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name, sort=sort)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundPlacementGroup
+    def get_by_name(self, name: str) -> BoundPlacementGroup:
         """Get Placement Group by name
 
         :param name: str
@@ -132,11 +135,10 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        name,  # type: str
-        type,  # type: str
-        labels=None,  # type: Optional[Dict[str, str]]
-    ):
-        # type: (...) -> CreatePlacementGroupResponse
+        name: str,
+        type: str,
+        labels: dict[str, str] | None = None,
+    ) -> CreatePlacementGroupResponse:
         """Creates a new Placement Group.
 
         :param name: str
@@ -165,8 +167,12 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return result
 
-    def update(self, placement_group, labels=None, name=None):
-        # type: (PlacementGroup, Optional[Dict[str, str]], Optional[str]) -> BoundPlacementGroup
+    def update(
+        self,
+        placement_group: PlacementGroup,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundPlacementGroup:
         """Updates the description or labels of a Placement Group.
 
         :param placement_group: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>` or :class:`PlacementGroup <hcloud.placement_groups.domain.PlacementGroup>`
@@ -192,8 +198,7 @@ class PlacementGroupsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundPlacementGroup(self, response["placement_group"])
 
-    def delete(self, placement_group):
-        # type: (PlacementGroup) -> bool
+    def delete(self, placement_group: PlacementGroup) -> bool:
         """Deletes a Placement Group.
 
         :param placement_group: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>` or :class:`PlacementGroup <hcloud.placement_groups.domain.PlacementGroup>`

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -36,7 +36,13 @@ class PlacementGroup(BaseDomain):
     TYPE_SPREAD = "spread"
 
     def __init__(
-        self, id=None, name=None, labels=None, servers=None, type=None, created=None
+        self,
+        id=None,
+        name=None,
+        labels=None,
+        servers=None,
+        type=None,
+        created=None,
     ):
         self.id = id
         self.name = name

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -66,7 +66,7 @@ class CreatePlacementGroupResponse(BaseDomain):
     def __init__(
         self,
         placement_group: BoundPlacementGroup,
-        action: BoundAction,
+        action: BoundAction | None,
     ):
         self.placement_group = placement_group
         self.action = action

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundPlacementGroup
 
 
 class PlacementGroup(BaseDomain):
@@ -53,8 +59,8 @@ class CreatePlacementGroupResponse(BaseDomain):
 
     def __init__(
         self,
-        placement_group,  # type: BoundPlacementGroup
-        action,  # type: BoundAction
+        placement_group: BoundPlacementGroup,
+        action: BoundAction,
     ):
         self.placement_group = placement_group
         self.action = action

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -8,7 +8,7 @@ from .domain import CreatePrimaryIPResponse, PrimaryIP
 
 if TYPE_CHECKING:
     from .._client import Client
-    from ..datacenters.domain import Datacenter
+    from ..datacenters import BoundDatacenter, Datacenter
 
 
 class BoundPrimaryIP(BoundModelBase):
@@ -16,7 +16,7 @@ class BoundPrimaryIP(BoundModelBase):
 
     model = PrimaryIP
 
-    def __init__(self, client, data, complete=True):
+    def __init__(self, client: PrimaryIPsClient, data: dict, complete: bool = True):
         from ..datacenters import BoundDatacenter
 
         datacenter = data.get("datacenter", {})
@@ -130,7 +130,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
                Can be used to filter resources by their ip. The response will only contain the resources matching the specified ip.
         :return: (List[:class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
 
         if label_selector is not None:
             params["label_selector"] = label_selector
@@ -166,7 +166,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name)
 
-    def get_by_name(self, name: str) -> BoundPrimaryIP:
+    def get_by_name(self, name: str) -> BoundPrimaryIP | None:
         """Get Primary IP by name
 
         :param name: str
@@ -178,7 +178,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
     def create(
         self,
         type: str,
-        datacenter: Datacenter,
+        datacenter: Datacenter | BoundDatacenter,
         name: str,
         assignee_type: str | None = "server",
         assignee_id: int | None = None,
@@ -199,7 +199,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         :return: :class:`CreatePrimaryIPResponse <hcloud.primary_ips.domain.CreatePrimaryIPResponse>`
         """
 
-        data = {
+        data: dict[str, Any] = {
             "type": type,
             "assignee_type": assignee_type,
             "auto_delete": auto_delete,
@@ -224,7 +224,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        primary_ip: PrimaryIP,
+        primary_ip: PrimaryIP | BoundPrimaryIP,
         auto_delete: bool | None = None,
         labels: dict[str, str] | None = None,
         name: str | None = None,
@@ -240,7 +240,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
                New name to set
         :return: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if auto_delete is not None:
             data["auto_delete"] = auto_delete
         if labels is not None:
@@ -255,7 +255,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundPrimaryIP(self, response["primary_ip"])
 
-    def delete(self, primary_ip: PrimaryIP) -> bool:
+    def delete(self, primary_ip: PrimaryIP | BoundPrimaryIP) -> bool:
         """Deletes a Primary IP. If it is currently assigned to an assignee it will automatically get unassigned.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -270,7 +270,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def change_protection(
         self,
-        primary_ip: PrimaryIP,
+        primary_ip: PrimaryIP | BoundPrimaryIP,
         delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of the Primary IP.
@@ -280,7 +280,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
                If true, prevents the Primary IP from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if delete is not None:
             data.update({"delete": delete})
 
@@ -295,7 +295,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def assign(
         self,
-        primary_ip: PrimaryIP,
+        primary_ip: PrimaryIP | BoundPrimaryIP,
         assignee_id: int,
         assignee_type: str = "server",
     ) -> BoundAction:
@@ -317,7 +317,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def unassign(self, primary_ip: PrimaryIP) -> BoundAction:
+    def unassign(self, primary_ip: PrimaryIP | BoundPrimaryIP) -> BoundAction:
         """Unassigns a Primary IP, resulting in it being unreachable. You may assign it to a server again at a later time.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -333,7 +333,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def change_dns_ptr(
         self,
-        primary_ip: PrimaryIP,
+        primary_ip: PrimaryIP | BoundPrimaryIP,
         ip: str,
         dns_ptr: str,
     ) -> BoundAction:

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -152,7 +152,9 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return PrimaryIPsPageResult(primary_ips, Meta.parse_meta(response))
 
     def get_all(
-        self, label_selector: str | None = None, name: str | None = None
+        self,
+        label_selector: str | None = None,
+        name: str | None = None,
     ) -> list[BoundPrimaryIP]:
         """Get all primary ips from this account
 
@@ -267,7 +269,9 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return True
 
     def change_protection(
-        self, primary_ip: PrimaryIP, delete: bool | None = None
+        self,
+        primary_ip: PrimaryIP,
+        delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of the Primary IP.
 
@@ -290,7 +294,10 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def assign(
-        self, primary_ip: PrimaryIP, assignee_id: int, assignee_type: str = "server"
+        self,
+        primary_ip: PrimaryIP,
+        assignee_id: int,
+        assignee_type: str = "server",
     ) -> BoundAction:
         """Assigns a Primary IP to a assignee_id.
 
@@ -325,7 +332,10 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def change_dns_ptr(
-        self, primary_ip: PrimaryIP, ip: str, dns_ptr: str
+        self,
+        primary_ip: PrimaryIP,
+        ip: str,
+        dns_ptr: str,
     ) -> BoundAction:
         """Changes the dns ptr that will appear when getting the dns ptr belonging to this Primary IP.
 

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -8,6 +8,7 @@ from .domain import CreatePrimaryIPResponse, PrimaryIP
 
 if TYPE_CHECKING:
     from .._client import Client
+    from ..datacenters.domain import Datacenter
 
 
 class BoundPrimaryIP(BoundModelBase):
@@ -24,8 +25,12 @@ class BoundPrimaryIP(BoundModelBase):
 
         super().__init__(client, data, complete)
 
-    def update(self, auto_delete=None, labels=None, name=None):
-        # type: (Optional[bool], Optional[Dict[str, str]], Optional[str]) -> BoundPrimaryIP
+    def update(
+        self,
+        auto_delete: bool | None = None,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundPrimaryIP:
         """Updates the description or labels of a Primary IP.
 
         :param auto_delete: bool (optional)
@@ -40,16 +45,14 @@ class BoundPrimaryIP(BoundModelBase):
             self, auto_delete=auto_delete, labels=labels, name=name
         )
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes a Primary IP. If it is currently assigned to a server it will automatically get unassigned.
 
         :return: boolean
         """
         return self._client.delete(self)
 
-    def change_protection(self, delete=None):
-        # type: (Optional[bool]) -> BoundAction
+    def change_protection(self, delete: bool | None = None) -> BoundAction:
         """Changes the protection configuration of the Primary IP.
 
         :param delete: boolean
@@ -58,8 +61,7 @@ class BoundPrimaryIP(BoundModelBase):
         """
         return self._client.change_protection(self, delete)
 
-    def assign(self, assignee_id, assignee_type):
-        # type: (int,str) -> BoundAction
+    def assign(self, assignee_id: int, assignee_type: str) -> BoundAction:
         """Assigns a Primary IP to a assignee.
 
         :param assignee_id: int`
@@ -70,16 +72,14 @@ class BoundPrimaryIP(BoundModelBase):
         """
         return self._client.assign(self, assignee_id, assignee_type)
 
-    def unassign(self):
-        # type: () -> BoundAction
+    def unassign(self) -> BoundAction:
         """Unassigns a Primary IP, resulting in it being unreachable. You may assign it to a server again at a later time.
 
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.unassign(self)
 
-    def change_dns_ptr(self, ip, dns_ptr):
-        # type: (str, str) -> BoundAction
+    def change_dns_ptr(self, ip: str, dns_ptr: str) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to this Primary IP.
 
         :param ip: str
@@ -99,8 +99,7 @@ class PrimaryIPsPageResult(NamedTuple):
 class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundPrimaryIP
+    def get_by_id(self, id: int) -> BoundPrimaryIP:
         """Returns a specific Primary IP object.
 
         :param id: int
@@ -111,13 +110,12 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        name=None,  # type: Optional[str]
-        ip=None,  # type: Optional[ip]
-    ):
-        # type: (...) -> PageResults[List[BoundPrimaryIP]]
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        name: str | None = None,
+        ip: str | None = None,
+    ) -> PrimaryIPsPageResult:
         """Get a list of primary ips from this account
 
         :param label_selector: str (optional)
@@ -153,8 +151,9 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
         return PrimaryIPsPageResult(primary_ips, Meta.parse_meta(response))
 
-    def get_all(self, label_selector=None, name=None):
-        # type: (Optional[str], Optional[str]) -> List[BoundPrimaryIP]
+    def get_all(
+        self, label_selector: str | None = None, name: str | None = None
+    ) -> list[BoundPrimaryIP]:
         """Get all primary ips from this account
 
         :param label_selector: str (optional)
@@ -165,8 +164,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, name=name)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundPrimaryIP
+    def get_by_name(self, name: str) -> BoundPrimaryIP:
         """Get Primary IP by name
 
         :param name: str
@@ -177,15 +175,14 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        type,  # type: str
-        datacenter,  # type: Datacenter
-        name,  # type: str
-        assignee_type="server",  # type: Optional[str]
-        assignee_id=None,  # type: Optional[int]
-        auto_delete=False,  # type: Optional[bool]
-        labels=None,  # type: Optional[dict]
-    ):
-        # type: (...) -> CreatePrimaryIPResponse
+        type: str,
+        datacenter: Datacenter,
+        name: str,
+        assignee_type: str | None = "server",
+        assignee_id: int | None = None,
+        auto_delete: bool | None = False,
+        labels: dict | None = None,
+    ) -> CreatePrimaryIPResponse:
         """Creates a new Primary IP assigned to a server.
 
         :param type: str
@@ -223,8 +220,13 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return result
 
-    def update(self, primary_ip, auto_delete=None, labels=None, name=None):
-        # type: (PrimaryIP,  Optional[bool], Optional[Dict[str, str]], Optional[str]) -> BoundPrimaryIP
+    def update(
+        self,
+        primary_ip: PrimaryIP,
+        auto_delete: bool | None = None,
+        labels: dict[str, str] | None = None,
+        name: str | None = None,
+    ) -> BoundPrimaryIP:
         """Updates the name, auto_delete or labels of a Primary IP.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -251,8 +253,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundPrimaryIP(self, response["primary_ip"])
 
-    def delete(self, primary_ip):
-        # type: (PrimaryIP) -> bool
+    def delete(self, primary_ip: PrimaryIP) -> bool:
         """Deletes a Primary IP. If it is currently assigned to an assignee it will automatically get unassigned.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -265,8 +266,9 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         # Return always true, because the API does not return an action for it. When an error occurs a HcloudAPIException will be raised
         return True
 
-    def change_protection(self, primary_ip, delete=None):
-        # type: (PrimaryIP, Optional[bool]) -> BoundAction
+    def change_protection(
+        self, primary_ip: PrimaryIP, delete: bool | None = None
+    ) -> BoundAction:
         """Changes the protection configuration of the Primary IP.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -287,8 +289,9 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def assign(self, primary_ip, assignee_id, assignee_type="server"):
-        # type: (PrimaryIP, int, str) -> BoundAction
+    def assign(
+        self, primary_ip: PrimaryIP, assignee_id: int, assignee_type: str = "server"
+    ) -> BoundAction:
         """Assigns a Primary IP to a assignee_id.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -307,8 +310,7 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def unassign(self, primary_ip):
-        # type: (PrimaryIP) -> BoundAction
+    def unassign(self, primary_ip: PrimaryIP) -> BoundAction:
         """Unassigns a Primary IP, resulting in it being unreachable. You may assign it to a server again at a later time.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`
@@ -322,8 +324,9 @@ class PrimaryIPsClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_dns_ptr(self, primary_ip, ip, dns_ptr):
-        # type: (PrimaryIP, str, str) -> BoundAction
+    def change_dns_ptr(
+        self, primary_ip: PrimaryIP, ip: str, dns_ptr: str
+    ) -> BoundAction:
         """Changes the dns ptr that will appear when getting the dns ptr belonging to this Primary IP.
 
         :param primary_ip: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>` or  :class:`PrimaryIP <hcloud.primary_ips.domain.PrimaryIP>`

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -103,7 +103,7 @@ class CreatePrimaryIPResponse(BaseDomain):
     def __init__(
         self,
         primary_ip: BoundPrimaryIP,
-        action: BoundAction,
+        action: BoundAction | None,
     ):
         self.primary_ip = primary_ip
         self.action = action

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundPrimaryIP
 
 
 class PrimaryIP(BaseDomain):
@@ -96,8 +102,8 @@ class CreatePrimaryIPResponse(BaseDomain):
 
     def __init__(
         self,
-        primary_ip,  # type: BoundPrimaryIP
-        action,  # type: BoundAction
+        primary_ip: BoundPrimaryIP,
+        action: BoundAction,
     ):
         self.primary_ip = primary_ip
         self.action = action

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -23,8 +23,7 @@ class ServerTypesPageResult(NamedTuple):
 class ServerTypesClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundServerType
+    def get_by_id(self, id: int) -> BoundServerType:
         """Returns a specific Server Type.
 
         :param id: int
@@ -33,8 +32,12 @@ class ServerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         response = self._client.request(url=f"/server_types/{id}", method="GET")
         return BoundServerType(self, response["server_type"])
 
-    def get_list(self, name=None, page=None, per_page=None):
-        # type: (Optional[str], Optional[int], Optional[int]) -> PageResults[List[BoundServerType], Meta]
+    def get_list(
+        self,
+        name: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ServerTypesPageResult:
         """Get a list of Server types
 
         :param name: str (optional)
@@ -62,8 +65,7 @@ class ServerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return ServerTypesPageResult(server_types, Meta.parse_meta(response))
 
-    def get_all(self, name=None):
-        # type: (Optional[str]) -> List[BoundServerType]
+    def get_all(self, name: str | None = None) -> list[BoundServerType]:
         """Get all Server types
 
         :param name: str (optional)
@@ -72,8 +74,7 @@ class ServerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundServerType
+    def get_by_name(self, name: str) -> BoundServerType:
         """Get Server type by name
 
         :param name: str

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import ServerType
@@ -48,7 +48,7 @@ class ServerTypesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundServerType <hcloud.server_types.client.BoundServerType>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if page is not None:
@@ -74,7 +74,7 @@ class ServerTypesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name)
 
-    def get_by_name(self, name: str) -> BoundServerType:
+    def get_by_name(self, name: str) -> BoundServerType | None:
         """Get Server type by name
 
         :param name: str

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -296,7 +296,7 @@ class BoundServer(BoundModelBase):
         """
         return self._client.create_image(self, description, type, labels)
 
-    def rebuild(self, image: Image) -> BoundAction:
+    def rebuild(self, image: Image | BoundImage) -> BoundAction:
         """Rebuilds a server overwriting its disk with the content of an image, thereby destroying all data on the target server.
 
         :param image: :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.servers.domain.Image>`
@@ -306,7 +306,7 @@ class BoundServer(BoundModelBase):
 
     def change_type(
         self,
-        server_type: BoundServerType,
+        server_type: ServerType | BoundServerType,
         upgrade_disk: bool,
     ) -> BoundAction:
         """Changes the type (Cores, RAM and disk sizes) of a server.
@@ -333,7 +333,7 @@ class BoundServer(BoundModelBase):
         """
         return self._client.disable_backup(self)
 
-    def attach_iso(self, iso: Iso) -> BoundAction:
+    def attach_iso(self, iso: Iso | BoundIso) -> BoundAction:
         """Attaches an ISO to a server.
 
         :param iso: :class:`BoundIso <hcloud.isos.client.BoundIso>` or :class:`Server <hcloud.isos.domain.Iso>`

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -30,6 +30,16 @@ from .domain import (
 
 if TYPE_CHECKING:
     from .._client import Client
+    from ..datacenters import Datacenter
+    from ..firewalls import Firewall
+    from ..images import Image
+    from ..isos import Iso
+    from ..locations import Location
+    from ..placement_groups import PlacementGroup
+    from ..server_types import ServerType
+    from ..ssh_keys import SSHKey
+    from ..volumes import Volume
+    from .domain import ServerCreatePublicNetwork
 
 
 class BoundServer(BoundModelBase):
@@ -144,8 +154,13 @@ class BoundServer(BoundModelBase):
 
         super().__init__(client, data, complete)
 
-    def get_actions_list(self, status=None, sort=None, page=None, per_page=None):
-        # type: (Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction, Meta]]
+    def get_actions_list(
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a server.
 
         :param status: List[str] (optional)
@@ -160,8 +175,9 @@ class BoundServer(BoundModelBase):
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
-    def get_actions(self, status=None, sort=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self, status: list[str] | None = None, sort: list[str] | None = None
+    ) -> list[BoundAction]:
         """Returns all action objects for a server.
 
         :param status: List[str] (optional)
@@ -172,8 +188,9 @@ class BoundServer(BoundModelBase):
         """
         return self._client.get_actions(self, status, sort)
 
-    def update(self, name=None, labels=None):
-        # type: (Optional[str], Optional[Dict[str, str]]) -> BoundServer
+    def update(
+        self, name: str | None = None, labels: dict[str, str] | None = None
+    ) -> BoundServer:
         """Updates a server. You can update a server’s name and a server’s labels.
 
         :param name: str (optional)
@@ -184,64 +201,58 @@ class BoundServer(BoundModelBase):
         """
         return self._client.update(self, name, labels)
 
-    def delete(self):
-        # type: () -> BoundAction
+    def delete(self) -> BoundAction:
         """Deletes a server. This immediately removes the server from your account, and it is no longer accessible.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.delete(self)
 
-    def power_off(self):
-        # type: () -> BoundAction
+    def power_off(self) -> BoundAction:
         """Cuts power to the server. This forcefully stops it without giving the server operating system time to gracefully stop
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.power_off(self)
 
-    def power_on(self):
-        # type: () -> BoundAction
+    def power_on(self) -> BoundAction:
         """Starts a server by turning its power on.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.power_on(self)
 
-    def reboot(self):
-        # type: () -> BoundAction
+    def reboot(self) -> BoundAction:
         """Reboots a server gracefully by sending an ACPI request.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.reboot(self)
 
-    def reset(self):
-        # type: () -> BoundAction
+    def reset(self) -> BoundAction:
         """Cuts power to a server and starts it again.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.reset(self)
 
-    def shutdown(self):
-        # type: () -> BoundAction
+    def shutdown(self) -> BoundAction:
         """Shuts down a server gracefully by sending an ACPI shutdown request.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.shutdown(self)
 
-    def reset_password(self):
-        # type: () -> ResetPasswordResponse
+    def reset_password(self) -> ResetPasswordResponse:
         """Resets the root password. Only works for Linux systems that are running the qemu guest agent.
 
         :return: :class:`ResetPasswordResponse <hcloud.servers.domain.ResetPasswordResponse>`
         """
         return self._client.reset_password(self)
 
-    def enable_rescue(self, type=None, ssh_keys=None):
-        # type: (str, Optional[List[str]]) -> EnableRescueResponse
+    def enable_rescue(
+        self, type: str | None = None, ssh_keys: list[str] | None = None
+    ) -> EnableRescueResponse:
         """Enable the Hetzner Rescue System for this server.
 
         :param type: str
@@ -253,16 +264,19 @@ class BoundServer(BoundModelBase):
         """
         return self._client.enable_rescue(self, type=type, ssh_keys=ssh_keys)
 
-    def disable_rescue(self):
-        # type: () -> BoundAction
+    def disable_rescue(self) -> BoundAction:
         """Disables the Hetzner Rescue System for a server.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.disable_rescue(self)
 
-    def create_image(self, description=None, type=None, labels=None):
-        # type: (str, str, Optional[Dict[str, str]]) -> CreateImageResponse
+    def create_image(
+        self,
+        description: str | None = None,
+        type: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> CreateImageResponse:
         """Creates an image (snapshot) from a server by copying the contents of its disks.
 
         :param description: str (optional)
@@ -276,8 +290,7 @@ class BoundServer(BoundModelBase):
         """
         return self._client.create_image(self, description, type, labels)
 
-    def rebuild(self, image):
-        # type: (Image) -> BoundAction
+    def rebuild(self, image: Image) -> BoundAction:
         """Rebuilds a server overwriting its disk with the content of an image, thereby destroying all data on the target server.
 
         :param image: :class:`BoundImage <hcloud.images.client.BoundImage>` or :class:`Image <hcloud.servers.domain.Image>`
@@ -285,8 +298,9 @@ class BoundServer(BoundModelBase):
         """
         return self._client.rebuild(self, image)
 
-    def change_type(self, server_type, upgrade_disk):
-        # type: (BoundServerType, bool) -> BoundAction
+    def change_type(
+        self, server_type: BoundServerType, upgrade_disk: bool
+    ) -> BoundAction:
         """Changes the type (Cores, RAM and disk sizes) of a server.
 
         :param server_type: :class:`BoundServerType <hcloud.server_types.client.BoundServerType>` or :class:`ServerType <hcloud.server_types.domain.ServerType>`
@@ -297,24 +311,21 @@ class BoundServer(BoundModelBase):
         """
         return self._client.change_type(self, server_type, upgrade_disk)
 
-    def enable_backup(self):
-        # type: () -> BoundAction
+    def enable_backup(self) -> BoundAction:
         """Enables and configures the automatic daily backup option for the server. Enabling automatic backups will increase the price of the server by 20%.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.enable_backup(self)
 
-    def disable_backup(self):
-        # type: () -> BoundAction
+    def disable_backup(self) -> BoundAction:
         """Disables the automatic backup option and deletes all existing Backups for a Server.
 
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.disable_backup(self)
 
-    def attach_iso(self, iso):
-        # type: (Iso) -> BoundAction
+    def attach_iso(self, iso: Iso) -> BoundAction:
         """Attaches an ISO to a server.
 
         :param iso: :class:`BoundIso <hcloud.isos.client.BoundIso>` or :class:`Server <hcloud.isos.domain.Iso>`
@@ -322,16 +333,14 @@ class BoundServer(BoundModelBase):
         """
         return self._client.attach_iso(self, iso)
 
-    def detach_iso(self):
-        # type: () -> BoundAction
+    def detach_iso(self) -> BoundAction:
         """Detaches an ISO from a server.
 
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
         return self._client.detach_iso(self)
 
-    def change_dns_ptr(self, ip, dns_ptr):
-        # type: (str, Optional[str]) -> BoundAction
+    def change_dns_ptr(self, ip: str, dns_ptr: str | None) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to the primary IPs (ipv4 and ipv6) of this server.
 
         :param ip: str
@@ -342,8 +351,9 @@ class BoundServer(BoundModelBase):
         """
         return self._client.change_dns_ptr(self, ip, dns_ptr)
 
-    def change_protection(self, delete=None, rebuild=None):
-        # type: (Optional[bool], Optional[bool]) -> BoundAction
+    def change_protection(
+        self, delete: bool | None = None, rebuild: bool | None = None
+    ) -> BoundAction:
         """Changes the protection configuration of the server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -355,16 +365,19 @@ class BoundServer(BoundModelBase):
         """
         return self._client.change_protection(self, delete, rebuild)
 
-    def request_console(self):
-        # type: () -> RequestConsoleResponse
+    def request_console(self) -> RequestConsoleResponse:
         """Requests credentials for remote access via vnc over websocket to keyboard, monitor, and mouse for a server.
 
         :return: :class:`RequestConsoleResponse <hcloud.servers.domain.RequestConsoleResponse>`
         """
         return self._client.request_console(self)
 
-    def attach_to_network(self, network, ip=None, alias_ips=None):
-        # type: (Union[Network,BoundNetwork],Optional[str], Optional[List[str]]) -> BoundAction
+    def attach_to_network(
+        self,
+        network: Network | BoundNetwork,
+        ip: str | None = None,
+        alias_ips: list[str] | None = None,
+    ) -> BoundAction:
         """Attaches a server to a network
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -376,8 +389,7 @@ class BoundServer(BoundModelBase):
         """
         return self._client.attach_to_network(self, network, ip, alias_ips)
 
-    def detach_from_network(self, network):
-        # type: ( Union[Network,BoundNetwork]) -> BoundAction
+    def detach_from_network(self, network: Network | BoundNetwork) -> BoundAction:
         """Detaches a server from a network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -385,8 +397,9 @@ class BoundServer(BoundModelBase):
         """
         return self._client.detach_from_network(self, network)
 
-    def change_alias_ips(self, network, alias_ips):
-        # type: (Union[Network,BoundNetwork], List[str]) -> BoundAction
+    def change_alias_ips(
+        self, network: Network | BoundNetwork, alias_ips: list[str]
+    ) -> BoundAction:
         """Changes the alias IPs of an already attached network.
 
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
@@ -396,8 +409,9 @@ class BoundServer(BoundModelBase):
         """
         return self._client.change_alias_ips(self, network, alias_ips)
 
-    def add_to_placement_group(self, placement_group):
-        # type: (Union[PlacementGroup,BoundPlacementGroup]) -> BoundAction
+    def add_to_placement_group(
+        self, placement_group: PlacementGroup | BoundPlacementGroup
+    ) -> BoundAction:
         """Adds a server to a placement group.
 
         :param placement_group: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>` or :class:`Network <hcloud.placement_groups.domain.PlacementGroup>`
@@ -405,8 +419,7 @@ class BoundServer(BoundModelBase):
         """
         return self._client.add_to_placement_group(self, placement_group)
 
-    def remove_from_placement_group(self):
-        # type: () -> BoundAction
+    def remove_from_placement_group(self) -> BoundAction:
         """Removes a server from a placement group.
 
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
@@ -422,8 +435,7 @@ class ServersPageResult(NamedTuple):
 class ServersClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundServer
+    def get_by_id(self, id: int) -> BoundServer:
         """Get a specific server
 
         :param id: int
@@ -434,13 +446,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-        status=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> PageResults[List[BoundServer], Meta]
+        name: str | None = None,
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+        status: list[str] | None = None,
+    ) -> ServersPageResult:
         """Get a list of servers from this account
 
         :param name: str (optional)
@@ -474,8 +485,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return ServersPageResult(ass_servers, Meta.parse_meta(response))
 
-    def get_all(self, name=None, label_selector=None, status=None):
-        # type: (Optional[str], Optional[str], Optional[List[str]]) -> List[BoundServer]
+    def get_all(
+        self,
+        name: str | None = None,
+        label_selector: str | None = None,
+        status: list[str] | None = None,
+    ) -> list[BoundServer]:
         """Get all servers from this account
 
         :param name: str (optional)
@@ -488,8 +503,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(name=name, label_selector=label_selector, status=status)
 
-    def get_by_name(self, name):
-        # type: (str) -> BoundServer
+    def get_by_name(self, name: str) -> BoundServer:
         """Get server by name
 
         :param name: str
@@ -500,23 +514,22 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
 
     def create(
         self,
-        name,  # type: str
-        server_type,  # type: ServerType
-        image,  # type: Image
-        ssh_keys=None,  # type: Optional[List[SSHKey]]
-        volumes=None,  # type: Optional[List[Volume]]
-        firewalls=None,  # type: Optional[List[Firewall]]
-        networks=None,  # type: Optional[List[Network]]
-        user_data=None,  # type: Optional[str]
-        labels=None,  # type: Optional[Dict[str, str]]
-        location=None,  # type: Optional[Location]
-        datacenter=None,  # type: Optional[Datacenter]
-        start_after_create=True,  # type: Optional[bool]
-        automount=None,  # type: Optional[bool]
-        placement_group=None,  # type: Optional[PlacementGroup]
-        public_net=None,  # type: Optional[ServerCreatePublicNetwork]
-    ):
-        # type: (...) -> CreateServerResponse
+        name: str,
+        server_type: ServerType,
+        image: Image,
+        ssh_keys: list[SSHKey] | None = None,
+        volumes: list[Volume] | None = None,
+        firewalls: list[Firewall] | None = None,
+        networks: list[Network] | None = None,
+        user_data: str | None = None,
+        labels: dict[str, str] | None = None,
+        location: Location | None = None,
+        datacenter: Datacenter | None = None,
+        start_after_create: bool | None = True,
+        automount: bool | None = None,
+        placement_group: PlacementGroup | None = None,
+        public_net: ServerCreatePublicNetwork | None = None,
+    ) -> CreateServerResponse:
         """Creates a new server. Returns preliminary information about the server as well as an action that covers progress of creation.
 
         :param name: str
@@ -600,9 +613,13 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         return result
 
     def get_actions_list(
-        self, server, status=None, sort=None, page=None, per_page=None
-    ):
-        # type: (Server, Optional[List[str]], Optional[List[str]], Optional[int], Optional[int]) -> PageResults[List[BoundAction], Meta]
+        self,
+        server: Server,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> ActionsPageResult:
         """Returns all action objects for a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -637,8 +654,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return ActionsPageResult(actions, Meta.parse_meta(response))
 
-    def get_actions(self, server, status=None, sort=None):
-        # type: (Server, Optional[List[str]], Optional[List[str]]) -> List[BoundAction]
+    def get_actions(
+        self,
+        server: Server,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[BoundAction]:
         """Returns all action objects for a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -650,8 +671,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_actions(server, status=status, sort=sort)
 
-    def update(self, server, name=None, labels=None):
-        # type:(Server,  Optional[str],  Optional[Dict[str, str]]) -> BoundServer
+    def update(
+        self,
+        server: Server,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundServer:
         """Updates a server. You can update a server’s name and a server’s labels.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -673,8 +698,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundServer(self, response["server"])
 
-    def delete(self, server):
-        # type: (Server) -> BoundAction
+    def delete(self, server: Server) -> BoundAction:
         """Deletes a server. This immediately removes the server from your account, and it is no longer accessible.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -683,8 +707,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         response = self._client.request(url=f"/servers/{server.id}", method="DELETE")
         return BoundAction(self._client.actions, response["action"])
 
-    def power_off(self, server):
-        # type: (Server) -> Action
+    def power_off(self, server: Server) -> BoundAction:
         """Cuts power to the server. This forcefully stops it without giving the server operating system time to gracefully stop
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -696,8 +719,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def power_on(self, server):
-        # type: (servers.domain.Server) -> actions.domain.Action
+    def power_on(self, server: Server) -> BoundAction:
         """Starts a server by turning its power on.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -709,8 +731,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def reboot(self, server):
-        # type: (servers.domain.Server) -> actions.domain.Action
+    def reboot(self, server: Server) -> BoundAction:
         """Reboots a server gracefully by sending an ACPI request.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -722,8 +743,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def reset(self, server):
-        # type: (servers.domain.Server) -> actions.domainAction
+    def reset(self, server: Server) -> BoundAction:
         """Cuts power to a server and starts it again.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -735,8 +755,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def shutdown(self, server):
-        # type: (servers.domain.Server) -> actions.domainAction
+    def shutdown(self, server: Server) -> BoundAction:
         """Shuts down a server gracefully by sending an ACPI shutdown request.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -748,8 +767,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def reset_password(self, server):
-        # type: (servers.domain.Server) -> ResetPasswordResponse
+    def reset_password(self, server: Server) -> ResetPasswordResponse:
         """Resets the root password. Only works for Linux systems that are running the qemu guest agent.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -766,8 +784,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
             root_password=response["root_password"],
         )
 
-    def change_type(self, server, server_type, upgrade_disk):
-        # type: (servers.domain.Server, BoundServerType, bool) -> actions.domainAction
+    def change_type(
+        self,
+        server: Server,
+        server_type: BoundServerType,
+        upgrade_disk: bool,
+    ) -> BoundAction:
         """Changes the type (Cores, RAM and disk sizes) of a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -785,8 +807,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def enable_rescue(self, server, type=None, ssh_keys=None):
-        # type: (servers.domain.Server, str, Optional[List[str]]) -> EnableRescueResponse
+    def enable_rescue(
+        self,
+        server: Server,
+        type: str | None = None,
+        ssh_keys: list[str] | None = None,
+    ) -> EnableRescueResponse:
         """Enable the Hetzner Rescue System for this server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -813,8 +839,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
             root_password=response["root_password"],
         )
 
-    def disable_rescue(self, server):
-        # type: (servers.domain.Server) -> actions.domainAction
+    def disable_rescue(self, server: Server) -> BoundAction:
         """Disables the Hetzner Rescue System for a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -828,8 +853,13 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def create_image(self, server, description=None, type=None, labels=None):
-        # type: (servers.domain.Server, str, str, Optional[Dict[str, str]]) -> CreateImageResponse
+    def create_image(
+        self,
+        server: Server,
+        description: str | None = None,
+        type: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> CreateImageResponse:
         """Creates an image (snapshot) from a server by copying the contents of its disks.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -862,8 +892,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
             image=BoundImage(self._client.images, response["image"]),
         )
 
-    def rebuild(self, server, image):
-        # type: (servers.domain.Server, Image) -> actions.domainAction
+    def rebuild(self, server: Server, image: Image) -> BoundAction:
         """Rebuilds a server overwriting its disk with the content of an image, thereby destroying all data on the target server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -878,8 +907,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def enable_backup(self, server):
-        # type: (servers.domain.Server) -> actions.domainAction
+    def enable_backup(self, server: Server) -> BoundAction:
         """Enables and configures the automatic daily backup option for the server. Enabling automatic backups will increase the price of the server by 20%.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -893,8 +921,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def disable_backup(self, server):
-        # type: (servers.domain.Server) -> actions.domainAction
+    def disable_backup(self, server: Server) -> BoundAction:
         """Disables the automatic backup option and deletes all existing Backups for a Server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -908,8 +935,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def attach_iso(self, server, iso):
-        # type: (servers.domain.Server, Iso) -> actions.domainAction
+    def attach_iso(self, server: Server, iso: Iso) -> BoundAction:
         """Attaches an ISO to a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -924,8 +950,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def detach_iso(self, server):
-        # type: (servers.domain.Server) -> actions.domainAction
+    def detach_iso(self, server: Server) -> BoundAction:
         """Detaches an ISO from a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -937,8 +962,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_dns_ptr(self, server, ip, dns_ptr):
-        # type: (servers.domain.Server, str, str) -> actions.domainAction
+    def change_dns_ptr(self, server: Server, ip: str, dns_ptr: str) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to the primary IPs (ipv4 and ipv6) of this server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -958,8 +982,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_protection(self, server, delete=None, rebuild=None):
-        # type: (servers.domain.Server, Optional[bool], Optional[bool]) -> actions.domainAction
+    def change_protection(
+        self,
+        server: Server,
+        delete: bool | None = None,
+        rebuild: bool | None = None,
+    ) -> BoundAction:
         """Changes the protection configuration of the server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -984,8 +1012,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def request_console(self, server):
-        # type: (servers.domain.Server) -> RequestConsoleResponse
+    def request_console(self, server: Server) -> RequestConsoleResponse:
         """Requests credentials for remote access via vnc over websocket to keyboard, monitor, and mouse for a server.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -1003,8 +1030,13 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
             password=response["password"],
         )
 
-    def attach_to_network(self, server, network, ip=None, alias_ips=None):
-        # type: (Union[Server,BoundServer], Union[Network,BoundNetwork],Optional[str], Optional[List[str]]) -> BoundAction
+    def attach_to_network(
+        self,
+        server: Server | BoundServer,
+        network: Network | BoundNetwork,
+        ip: str | None = None,
+        alias_ips: list[str] | None = None,
+    ) -> BoundAction:
         """Attaches a server to a network
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -1029,8 +1061,9 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def detach_from_network(self, server, network):
-        # type: (Union[Server,BoundServer], Union[Network,BoundNetwork]) -> BoundAction
+    def detach_from_network(
+        self, server: Server | BoundServer, network: Network | BoundNetwork
+    ) -> BoundAction:
         """Detaches a server from a network.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -1047,8 +1080,12 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def change_alias_ips(self, server, network, alias_ips):
-        # type: (Union[Server,BoundServer], Union[Network,BoundNetwork], List[str]) -> BoundAction
+    def change_alias_ips(
+        self,
+        server: Server | BoundServer,
+        network: Network | BoundNetwork,
+        alias_ips: list[str],
+    ) -> BoundAction:
         """Changes the alias IPs of an already attached network.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -1067,8 +1104,11 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def add_to_placement_group(self, server, placement_group):
-        # type: (Union[Server,BoundServer], Union[PlacementGroup,BoundPlacementGroup]) -> BoundAction
+    def add_to_placement_group(
+        self,
+        server: Server | BoundServer,
+        placement_group: PlacementGroup | BoundPlacementGroup,
+    ) -> BoundAction:
         """Adds a server to a placement group.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`
@@ -1085,8 +1125,7 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundAction(self._client.actions, response["action"])
 
-    def remove_from_placement_group(self, server):
-        # type: (Union[Server,BoundServer]) -> BoundAction
+    def remove_from_placement_group(self, server: Server | BoundServer) -> BoundAction:
         """Removes a server from a placement group.
 
         :param server: :class:`BoundServer <hcloud.servers.client.BoundServer>` or :class:`Server <hcloud.servers.domain.Server>`

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -176,7 +176,9 @@ class BoundServer(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a server.
 
@@ -189,7 +191,9 @@ class BoundServer(BoundModelBase):
         return self._client.get_actions(self, status, sort)
 
     def update(
-        self, name: str | None = None, labels: dict[str, str] | None = None
+        self,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> BoundServer:
         """Updates a server. You can update a server’s name and a server’s labels.
 
@@ -251,7 +255,9 @@ class BoundServer(BoundModelBase):
         return self._client.reset_password(self)
 
     def enable_rescue(
-        self, type: str | None = None, ssh_keys: list[str] | None = None
+        self,
+        type: str | None = None,
+        ssh_keys: list[str] | None = None,
     ) -> EnableRescueResponse:
         """Enable the Hetzner Rescue System for this server.
 
@@ -299,7 +305,9 @@ class BoundServer(BoundModelBase):
         return self._client.rebuild(self, image)
 
     def change_type(
-        self, server_type: BoundServerType, upgrade_disk: bool
+        self,
+        server_type: BoundServerType,
+        upgrade_disk: bool,
     ) -> BoundAction:
         """Changes the type (Cores, RAM and disk sizes) of a server.
 
@@ -352,7 +360,9 @@ class BoundServer(BoundModelBase):
         return self._client.change_dns_ptr(self, ip, dns_ptr)
 
     def change_protection(
-        self, delete: bool | None = None, rebuild: bool | None = None
+        self,
+        delete: bool | None = None,
+        rebuild: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of the server.
 
@@ -398,7 +408,9 @@ class BoundServer(BoundModelBase):
         return self._client.detach_from_network(self, network)
 
     def change_alias_ips(
-        self, network: Network | BoundNetwork, alias_ips: list[str]
+        self,
+        network: Network | BoundNetwork,
+        alias_ips: list[str],
     ) -> BoundAction:
         """Changes the alias IPs of an already attached network.
 
@@ -410,7 +422,8 @@ class BoundServer(BoundModelBase):
         return self._client.change_alias_ips(self, network, alias_ips)
 
     def add_to_placement_group(
-        self, placement_group: PlacementGroup | BoundPlacementGroup
+        self,
+        placement_group: PlacementGroup | BoundPlacementGroup,
     ) -> BoundAction:
         """Adds a server to a placement group.
 
@@ -1062,7 +1075,9 @@ class ServersClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, response["action"])
 
     def detach_from_network(
-        self, server: Server | BoundServer, network: Network | BoundNetwork
+        self,
+        server: Server | BoundServer,
+        network: Network | BoundNetwork,
     ) -> BoundAction:
         """Detaches a server from a network.
 

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -165,7 +165,7 @@ class CreateServerResponse(BaseDomain):
         server: BoundServer,
         action: BoundAction,
         next_actions: list[BoundAction],
-        root_password: str,
+        root_password: str | None,
     ):
         self.server = server
         self.action = action

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain
+
+if TYPE_CHECKING:
+    from ..actions import Action, BoundAction
+    from ..firewalls import BoundFirewall
+    from ..floating_ips import BoundFloatingIP
+    from ..networks import BoundNetwork
+    from ..primary_ips import BoundPrimaryIP, PrimaryIP
+    from .client import BoundServer
 
 
 class Server(BaseDomain):
@@ -152,10 +162,10 @@ class CreateServerResponse(BaseDomain):
 
     def __init__(
         self,
-        server,  # type: BoundServer
-        action,  # type: BoundAction
-        next_actions,  # type: List[Action]
-        root_password,  # type: str
+        server: BoundServer,
+        action: BoundAction,
+        next_actions: list[Action],
+        root_password: str,
     ):
         self.server = server
         self.action = action
@@ -176,8 +186,8 @@ class ResetPasswordResponse(BaseDomain):
 
     def __init__(
         self,
-        action,  # type: BoundAction
-        root_password,  # type: str
+        action: BoundAction,
+        root_password: str,
     ):
         self.action = action
         self.root_password = root_password
@@ -196,8 +206,8 @@ class EnableRescueResponse(BaseDomain):
 
     def __init__(
         self,
-        action,  # type: BoundAction
-        root_password,  # type: str
+        action: BoundAction,
+        root_password: str,
     ):
         self.action = action
         self.root_password = root_password
@@ -218,9 +228,9 @@ class RequestConsoleResponse(BaseDomain):
 
     def __init__(
         self,
-        action,  # type: BoundAction
-        wss_url,  # type: str
-        password,  # type: str
+        action: BoundAction,
+        wss_url: str,
+        password: str,
     ):
         self.action = action
         self.wss_url = wss_url
@@ -249,12 +259,12 @@ class PublicNetwork(BaseDomain):
 
     def __init__(
         self,
-        ipv4,  # type: IPv4Address
-        ipv6,  # type: IPv6Network
-        floating_ips,  # type: List[BoundFloatingIP]
-        primary_ipv4,  # type: BoundPrimaryIP
-        primary_ipv6,  # type: BoundPrimaryIP
-        firewalls=None,  # type: List[PublicNetworkFirewall]
+        ipv4: IPv4Address,
+        ipv6: IPv6Network,
+        floating_ips: list[BoundFloatingIP],
+        primary_ipv4: BoundPrimaryIP,
+        primary_ipv6: BoundPrimaryIP,
+        firewalls: list[PublicNetworkFirewall] | None = None,
     ):
         self.ipv4 = ipv4
         self.ipv6 = ipv6
@@ -280,8 +290,8 @@ class PublicNetworkFirewall(BaseDomain):
 
     def __init__(
         self,
-        firewall,  # type: BoundFirewall
-        status,  # type: str
+        firewall: BoundFirewall,
+        status: str,
     ):
         self.firewall = firewall
         self.status = status
@@ -302,9 +312,9 @@ class IPv4Address(BaseDomain):
 
     def __init__(
         self,
-        ip,  # type: str
-        blocked,  # type: bool
-        dns_ptr,  # type: str
+        ip: str,
+        blocked: bool,
+        dns_ptr: str,
     ):
         self.ip = ip
         self.blocked = blocked
@@ -330,9 +340,9 @@ class IPv6Network(BaseDomain):
 
     def __init__(
         self,
-        ip,  # type: str
-        blocked,  # type: bool
-        dns_ptr,  # type: list
+        ip: str,
+        blocked: bool,
+        dns_ptr: list,
     ):
         self.ip = ip
         self.blocked = blocked
@@ -359,10 +369,10 @@ class PrivateNet(BaseDomain):
 
     def __init__(
         self,
-        network,  # type: BoundNetwork
-        ip,  # type: str
-        alias_ips,  # type: List[str]
-        mac_address,  # type: str
+        network: BoundNetwork,
+        ip: str,
+        alias_ips: list[str],
+        mac_address: str,
     ):
         self.network = network
         self.ip = ip
@@ -383,10 +393,10 @@ class ServerCreatePublicNetwork(BaseDomain):
 
     def __init__(
         self,
-        ipv4=None,  # type: hcloud.primary_ips.domain.PrimaryIP
-        ipv6=None,  # type: hcloud.primary_ips.domain.PrimaryIP
-        enable_ipv4=True,  # type: bool
-        enable_ipv6=True,  # type: bool
+        ipv4: PrimaryIP | None = None,
+        ipv6: PrimaryIP | None = None,
+        enable_ipv4: bool = True,
+        enable_ipv6: bool = True,
     ):
         self.ipv4 = ipv4
         self.ipv6 = ipv6

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -7,7 +7,7 @@ from dateutil.parser import isoparse
 from ..core import BaseDomain
 
 if TYPE_CHECKING:
-    from ..actions import Action, BoundAction
+    from ..actions import BoundAction
     from ..firewalls import BoundFirewall
     from ..floating_ips import BoundFloatingIP
     from ..networks import BoundNetwork
@@ -164,7 +164,7 @@ class CreateServerResponse(BaseDomain):
         self,
         server: BoundServer,
         action: BoundAction,
-        next_actions: list[Action],
+        next_actions: list[BoundAction],
         root_password: str,
     ):
         self.server = server
@@ -262,8 +262,8 @@ class PublicNetwork(BaseDomain):
         ipv4: IPv4Address,
         ipv6: IPv6Network,
         floating_ips: list[BoundFloatingIP],
-        primary_ipv4: BoundPrimaryIP,
-        primary_ipv6: BoundPrimaryIP,
+        primary_ipv4: BoundPrimaryIP | None,
+        primary_ipv6: BoundPrimaryIP | None,
         firewalls: list[PublicNetworkFirewall] | None = None,
     ):
         self.ipv4 = ipv4

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import SSHKey
@@ -75,7 +75,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return:  (List[:class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if fingerprint is not None:
@@ -114,7 +114,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
             name=name, fingerprint=fingerprint, label_selector=label_selector
         )
 
-    def get_by_name(self, name: str) -> SSHKeysClient:
+    def get_by_name(self, name: str) -> BoundSSHKey | None:
         """Get ssh key by name
 
         :param name: str
@@ -123,7 +123,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_by_name(name)
 
-    def get_by_fingerprint(self, fingerprint: str) -> BoundSSHKey:
+    def get_by_fingerprint(self, fingerprint: str) -> BoundSSHKey | None:
         """Get ssh key by fingerprint
 
         :param fingerprint: str
@@ -149,7 +149,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>`
         """
-        data = {"name": name, "public_key": public_key}
+        data: dict[str, Any] = {"name": name, "public_key": public_key}
         if labels is not None:
             data["labels"] = labels
         response = self._client.request(url="/ssh_keys", method="POST", json=data)
@@ -157,7 +157,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
 
     def update(
         self,
-        ssh_key: SSHKey,
+        ssh_key: SSHKey | BoundSSHKey,
         name: str | None = None,
         labels: dict[str, str] | None = None,
     ) -> BoundSSHKey:
@@ -170,7 +170,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if name is not None:
             data["name"] = name
         if labels is not None:
@@ -182,7 +182,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundSSHKey(self, response["ssh_key"])
 
-    def delete(self, ssh_key: SSHKey) -> bool:
+    def delete(self, ssh_key: SSHKey | BoundSSHKey) -> bool:
         self._client.request(url=f"/ssh_keys/{ssh_key.id}", method="DELETE")
         """Deletes an SSH key. It cannot be used anymore.
 

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -15,7 +15,9 @@ class BoundSSHKey(BoundModelBase):
     model = SSHKey
 
     def update(
-        self, name: str | None = None, labels: dict[str, str] | None = None
+        self,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> BoundSSHKey:
         """Updates an SSH key. You can update an SSH key name and an SSH key labels.
 
@@ -133,7 +135,10 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         return sshkeys[0] if sshkeys else None
 
     def create(
-        self, name: str, public_key: str, labels: dict[str, str] | None = None
+        self,
+        name: str,
+        public_key: str,
+        labels: dict[str, str] | None = None,
     ) -> BoundSSHKey:
         """Creates a new SSH key with the given name and public_key.
 

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -14,8 +14,9 @@ class BoundSSHKey(BoundModelBase):
 
     model = SSHKey
 
-    def update(self, name=None, labels=None):
-        # type: (Optional[str], Optional[Dict[str, str]]) -> BoundSSHKey
+    def update(
+        self, name: str | None = None, labels: dict[str, str] | None = None
+    ) -> BoundSSHKey:
         """Updates an SSH key. You can update an SSH key name and an SSH key labels.
 
         :param description: str (optional)
@@ -26,8 +27,7 @@ class BoundSSHKey(BoundModelBase):
         """
         return self._client.update(self, name, labels)
 
-    def delete(self):
-        # type: () -> bool
+    def delete(self) -> bool:
         """Deletes an SSH key. It cannot be used anymore.
         :return: boolean
         """
@@ -42,8 +42,7 @@ class SSHKeysPageResult(NamedTuple):
 class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
     _client: Client
 
-    def get_by_id(self, id):
-        # type: (int) -> BoundSSHKey
+    def get_by_id(self, id: int) -> BoundSSHKey:
         """Get a specific SSH Key by its ID
 
         :param id: int
@@ -54,13 +53,12 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_list(
         self,
-        name=None,  # type: Optional[str]
-        fingerprint=None,  # type: Optional[str]
-        label_selector=None,  # type: Optional[str]
-        page=None,  # type: Optional[int]
-        per_page=None,  # type: Optional[int]
-    ):
-        # type: (...) -> PageResults[List[BoundSSHKey], Meta]
+        name: str | None = None,
+        fingerprint: str | None = None,
+        label_selector: str | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ) -> SSHKeysPageResult:
         """Get a list of SSH keys from the account
 
         :param name: str (optional)
@@ -94,8 +92,12 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         ]
         return SSHKeysPageResult(ssh_keys, Meta.parse_meta(response))
 
-    def get_all(self, name=None, fingerprint=None, label_selector=None):
-        # type: (Optional[str], Optional[str], Optional[str]) -> List[BoundSSHKey]
+    def get_all(
+        self,
+        name: str | None = None,
+        fingerprint: str | None = None,
+        label_selector: str | None = None,
+    ) -> list[BoundSSHKey]:
         """Get all SSH keys from the account
 
         :param name: str (optional)
@@ -110,8 +112,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
             name=name, fingerprint=fingerprint, label_selector=label_selector
         )
 
-    def get_by_name(self, name):
-        # type: (str) -> SSHKeysClient
+    def get_by_name(self, name: str) -> SSHKeysClient:
         """Get ssh key by name
 
         :param name: str
@@ -120,8 +121,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_by_name(name)
 
-    def get_by_fingerprint(self, fingerprint):
-        # type: (str) -> BoundSSHKey
+    def get_by_fingerprint(self, fingerprint: str) -> BoundSSHKey:
         """Get ssh key by fingerprint
 
         :param fingerprint: str
@@ -132,8 +132,9 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         sshkeys = response.ssh_keys
         return sshkeys[0] if sshkeys else None
 
-    def create(self, name, public_key, labels=None):
-        # type: (str, str, Optional[Dict[str, str]]) -> BoundSSHKey
+    def create(
+        self, name: str, public_key: str, labels: dict[str, str] | None = None
+    ) -> BoundSSHKey:
         """Creates a new SSH key with the given name and public_key.
 
         :param name: str
@@ -149,8 +150,12 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         response = self._client.request(url="/ssh_keys", method="POST", json=data)
         return BoundSSHKey(self, response["ssh_key"])
 
-    def update(self, ssh_key, name=None, labels=None):
-        # type: (SSHKey,  Optional[str],  Optional[Dict[str, str]]) -> BoundSSHKey
+    def update(
+        self,
+        ssh_key: SSHKey,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> BoundSSHKey:
         """Updates an SSH key. You can update an SSH key name and an SSH key labels.
 
         :param ssh_key: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>` or  :class:`SSHKey <hcloud.ssh_keys.domain.SSHKey>`
@@ -172,8 +177,7 @@ class SSHKeysClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundSSHKey(self, response["ssh_key"])
 
-    def delete(self, ssh_key):
-        # type: (SSHKey) -> bool
+    def delete(self, ssh_key: SSHKey) -> bool:
         self._client.request(url=f"/ssh_keys/{ssh_key.id}", method="DELETE")
         """Deletes an SSH key. It cannot be used anymore.
 

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -54,7 +54,9 @@ class BoundVolume(BoundModelBase):
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
     def get_actions(
-        self, status: list[str] | None = None, sort: list[str] | None = None
+        self,
+        status: list[str] | None = None,
+        sort: list[str] | None = None,
     ) -> list[BoundAction]:
         """Returns all action objects for a volume.
 
@@ -67,7 +69,9 @@ class BoundVolume(BoundModelBase):
         return self._client.get_actions(self, status, sort)
 
     def update(
-        self, name: str | None = None, labels: dict[str, str] | None = None
+        self,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> BoundAction:
         """Updates the volume properties.
 
@@ -87,7 +91,9 @@ class BoundVolume(BoundModelBase):
         return self._client.delete(self)
 
     def attach(
-        self, server: Server | BoundServer, automount: bool | None = None
+        self,
+        server: Server | BoundServer,
+        automount: bool | None = None,
     ) -> BoundAction:
         """Attaches a volume to a server. Works only if the server is in the same location as the volume.
 
@@ -181,7 +187,9 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
         return VolumesPageResult(volumes, Meta.parse_meta(response))
 
     def get_all(
-        self, label_selector: str | None = None, status: list[str] | None = None
+        self,
+        label_selector: str | None = None,
+        status: list[str] | None = None,
     ) -> list[BoundVolume]:
         """Get all volumes from this account
 

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
@@ -18,7 +18,7 @@ class BoundVolume(BoundModelBase):
 
     model = Volume
 
-    def __init__(self, client, data, complete=True):
+    def __init__(self, client: VolumesClient, data: dict, complete: bool = True):
         location = data.get("location")
         if location is not None:
             data["location"] = BoundLocation(client._client.locations, location)
@@ -72,7 +72,7 @@ class BoundVolume(BoundModelBase):
         self,
         name: str | None = None,
         labels: dict[str, str] | None = None,
-    ) -> BoundAction:
+    ) -> BoundVolume:
         """Updates the volume properties.
 
         :param name: str (optional)
@@ -83,7 +83,7 @@ class BoundVolume(BoundModelBase):
         """
         return self._client.update(self, name, labels)
 
-    def delete(self) -> BoundAction:
+    def delete(self) -> bool:
         """Deletes a volume. All volume data is irreversibly destroyed. The volume must not be attached to a server and it must not have delete protection enabled.
 
         :return: boolean
@@ -168,7 +168,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundVolume <hcloud.volumes.client.BoundVolume>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if name is not None:
             params["name"] = name
         if label_selector is not None:
@@ -201,7 +201,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
         """
         return super().get_all(label_selector=label_selector, status=status)
 
-    def get_by_name(self, name: str) -> BoundVolume:
+    def get_by_name(self, name: str) -> BoundVolume | None:
         """Get volume by name
 
         :param name: str
@@ -243,7 +243,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
         if not (bool(location) ^ bool(server)):
             raise ValueError("only one of server or location must be provided")
 
-        data = {"name": name, "size": size}
+        data: dict[str, Any] = {"name": name, "size": size}
         if labels is not None:
             data["labels"] = labels
         if location is not None:
@@ -270,7 +270,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
 
     def get_actions_list(
         self,
-        volume: Volume,
+        volume: Volume | BoundVolume,
         status: list[str] | None = None,
         sort: list[str] | None = None,
         page: int | None = None,
@@ -289,7 +289,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        params = {}
+        params: dict[str, Any] = {}
         if status is not None:
             params["status"] = status
         if sort is not None:
@@ -342,7 +342,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
                User-defined labels (key-value pairs)
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if name is not None:
             data.update({"name": name})
         if labels is not None:
@@ -354,7 +354,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
         )
         return BoundVolume(self, response["volume"])
 
-    def delete(self, volume: Volume | BoundVolume) -> BoundAction:
+    def delete(self, volume: Volume | BoundVolume) -> bool:
         """Deletes a volume. All volume data is irreversibly destroyed. The volume must not be attached to a server and it must not have delete protection enabled.
 
         :param volume: :class:`BoundVolume <hcloud.volumes.client.BoundVolume>` or :class:`Volume <hcloud.volumes.domain.Volume>`
@@ -391,7 +391,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
         :param automount: boolean
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {"server": server.id}
+        data: dict[str, Any] = {"server": server.id}
         if automount is not None:
             data["automount"] = automount
 
@@ -415,8 +415,8 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
         return BoundAction(self._client.actions, data["action"])
 
     def change_protection(
-        self: Volume | BoundVolume,
-        volume: bool | None,
+        self,
+        volume: Volume | BoundVolume,
         delete: bool | None = None,
     ) -> BoundAction:
         """Changes the protection configuration of a volume.
@@ -426,7 +426,7 @@ class VolumesClient(ClientEntityBase, GetEntityByNameMixin):
                If True, prevents the volume from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data = {}
+        data: dict[str, Any] = {}
         if delete is not None:
             data.update({"delete": delete})
 

--- a/hcloud/volumes/domain.py
+++ b/hcloud/volumes/domain.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from dateutil.parser import isoparse
 
 from ..core import BaseDomain, DomainIdentityMixin
+
+if TYPE_CHECKING:
+    from ..actions import BoundAction
+    from .client import BoundVolume
 
 
 class Volume(BaseDomain, DomainIdentityMixin):
@@ -93,9 +99,9 @@ class CreateVolumeResponse(BaseDomain):
 
     def __init__(
         self,
-        volume,  # type: BoundVolume
-        action,  # type: BoundAction
-        next_actions,  # type: List[BoundAction]
+        volume: BoundVolume,
+        action: BoundAction,
+        next_actions: list[BoundAction],
     ):
         self.volume = volume
         self.action = action

--- a/hcloud/volumes/domain.py
+++ b/hcloud/volumes/domain.py
@@ -8,6 +8,8 @@ from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
+    from ..locations import BoundLocation, Location
+    from ..servers import BoundServer, Server
     from .client import BoundVolume
 
 
@@ -59,17 +61,17 @@ class Volume(BaseDomain, DomainIdentityMixin):
 
     def __init__(
         self,
-        id,
-        name=None,
-        server=None,
-        created=None,
-        location=None,
-        size=None,
-        linux_device=None,
-        format=None,
-        protection=None,
-        labels=None,
-        status=None,
+        id: int,
+        name: str | None = None,
+        server: Server | BoundServer | None = None,
+        created: str | None = None,
+        location: Location | BoundLocation | None = None,
+        size: int | None = None,
+        linux_device: str | None = None,
+        format: str | None = None,
+        protection: dict | None = None,
+        labels: dict[str, str] | None = None,
+        status: str | None = None,
     ):
         self.id = id
         self.name = name

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ setup(
         "test": [
             "coverage>=7.2.7,<7.3",
             "pytest>=7.4,<7.5",
+            "mypy>=1.4.1,<1.5",
+            "types-python-dateutil",
+            "types-requests",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
The converts the type comments into type hints, and adds a few extra typing fixes.
Also improved readability by breaking down long typed argument lists on multiple lines.

Removing the types from the docstrings will be done in a future PR or gradually while improving the docstrings.