### PR TITLE
feat: reexport references in parent ressources modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Here is an example that creates a server and list them:
 
 ```python
 from hcloud import Client
-from hcloud.images.domain import Image
-from hcloud.server_types.domain import ServerType
+from hcloud.images import Image
+from hcloud.server_types import ServerType
 
 client = Client(token="{YOUR_API_TOKEN}")  # Please paste your API token here
 

--- a/examples/create_server.py
+++ b/examples/create_server.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from hcloud import Client
-from hcloud.images.domain import Image
-from hcloud.server_types.domain import ServerType
+from hcloud.images import Image
+from hcloud.server_types import ServerType
 
 # Please paste your API token here between the quotes
 client = Client(token="{YOUR_API_TOKEN}")

--- a/examples/usage_oop.py
+++ b/examples/usage_oop.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from hcloud import Client
-from hcloud.images.domain import Image
-from hcloud.server_types.domain import ServerType
+from hcloud.images import Image
+from hcloud.server_types import ServerType
 
 # Create a client
 client = Client(token="project-token")

--- a/examples/usage_procedurale.py
+++ b/examples/usage_procedurale.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from hcloud import Client
-from hcloud.images.domain import Image
-from hcloud.server_types.domain import ServerType
-from hcloud.servers.domain import Server
-from hcloud.volumes.domain import Volume
+from hcloud.images import Image
+from hcloud.server_types import ServerType
+from hcloud.servers import Server
+from hcloud.volumes import Volume
 
 client = Client(token="project-token")
 

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -6,23 +6,23 @@ import requests
 
 from .__version__ import VERSION
 from ._exceptions import APIException
-from .actions.client import ActionsClient
-from .certificates.client import CertificatesClient
-from .datacenters.client import DatacentersClient
-from .firewalls.client import FirewallsClient
-from .floating_ips.client import FloatingIPsClient
-from .images.client import ImagesClient
-from .isos.client import IsosClient
-from .load_balancer_types.client import LoadBalancerTypesClient
-from .load_balancers.client import LoadBalancersClient
-from .locations.client import LocationsClient
-from .networks.client import NetworksClient
-from .placement_groups.client import PlacementGroupsClient
-from .primary_ips.client import PrimaryIPsClient
-from .server_types.client import ServerTypesClient
-from .servers.client import ServersClient
-from .ssh_keys.client import SSHKeysClient
-from .volumes.client import VolumesClient
+from .actions import ActionsClient
+from .certificates import CertificatesClient
+from .datacenters import DatacentersClient
+from .firewalls import FirewallsClient
+from .floating_ips import FloatingIPsClient
+from .images import ImagesClient
+from .isos import IsosClient
+from .load_balancer_types import LoadBalancerTypesClient
+from .load_balancers import LoadBalancersClient
+from .locations import LocationsClient
+from .networks import NetworksClient
+from .placement_groups import PlacementGroupsClient
+from .primary_ips import PrimaryIPsClient
+from .server_types import ServerTypesClient
+from .servers import ServersClient
+from .ssh_keys import SSHKeysClient
+from .volumes import VolumesClient
 
 
 class Client:

--- a/hcloud/actions/__init__.py
+++ b/hcloud/actions/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .client import ActionsClient, ActionsPageResult, BoundAction  # noqa: F401
+from .domain import (  # noqa: F401
+    Action,
+    ActionException,
+    ActionFailedException,
+    ActionTimeoutException,
+)

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core.client import BoundModelBase, ClientEntityBase
-from ..core.domain import Meta
+from ..core import BoundModelBase, ClientEntityBase
+from ..core import Meta
 from .domain import Action, ActionFailedException, ActionTimeoutException
 
 if TYPE_CHECKING:

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core import BoundModelBase, ClientEntityBase
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, Meta
 from .domain import Action, ActionFailedException, ActionTimeoutException
 
 if TYPE_CHECKING:

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dateutil.parser import isoparse
 
 from .._exceptions import HCloudException
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class Action(BaseDomain):

--- a/hcloud/certificates/__init__.py
+++ b/hcloud/certificates/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundCertificate,
+    CertificatesClient,
+    CertificatesPageResult,
+)
+from .domain import (  # noqa: F401
+    Certificate,
+    CreateManagedCertificateResponse,
+    ManagedCertificateError,
+    ManagedCertificateStatus,
+)

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import (
     Certificate,
     CreateManagedCertificateResponse,

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import (
     Certificate,
     CreateManagedCertificateResponse,

--- a/hcloud/certificates/domain.py
+++ b/hcloud/certificates/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class Certificate(BaseDomain, DomainIdentityMixin):

--- a/hcloud/core/__init__.py
+++ b/hcloud/core/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin  # noqa: F401
+from .domain import BaseDomain, DomainIdentityMixin, Meta, Pagination  # noqa: F401

--- a/hcloud/datacenters/__init__.py
+++ b/hcloud/datacenters/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundDatacenter,
+    DatacentersClient,
+    DatacentersPageResult,
+)
+from .domain import Datacenter, DatacenterServerTypes  # noqa: F401

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from ..locations import BoundLocation
 from ..server_types import BoundServerType
 from .domain import Datacenter, DatacenterServerTypes

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
-from ..locations.client import BoundLocation
-from ..server_types.client import BoundServerType
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
+from ..locations import BoundLocation
+from ..server_types import BoundServerType
 from .domain import Datacenter, DatacenterServerTypes
 
 if TYPE_CHECKING:

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class Datacenter(BaseDomain, DomainIdentityMixin):

--- a/hcloud/deprecation/__init__.py
+++ b/hcloud/deprecation/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .domain import DeprecationInfo  # noqa: F401

--- a/hcloud/deprecation/domain.py
+++ b/hcloud/deprecation/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class DeprecationInfo(BaseDomain):

--- a/hcloud/firewalls/__init__.py
+++ b/hcloud/firewalls/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .client import BoundFirewall, FirewallsClient, FirewallsPageResult  # noqa: F401
+from .domain import (  # noqa: F401
+    CreateFirewallResponse,
+    Firewall,
+    FirewallResource,
+    FirewallResourceLabelSelector,
+    FirewallRule,
+)

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import (
     CreateFirewallResponse,
     Firewall,
@@ -40,7 +40,7 @@ class BoundFirewall(BoundModelBase):
 
         applied_to = data.get("applied_to", [])
         if applied_to:
-            from ..servers.client import BoundServer
+            from ..servers import BoundServer
 
             ats = []
             for a in applied_to:

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import (
     CreateFirewallResponse,
     Firewall,

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class Firewall(BaseDomain):

--- a/hcloud/floating_ips/__init__.py
+++ b/hcloud/floating_ips/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundFloatingIP,
+    FloatingIPsClient,
+    FloatingIPsPageResult,
+)
+from .domain import CreateFloatingIPResponse, FloatingIP  # noqa: F401

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
-from ..locations.client import BoundLocation
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
+from ..locations import BoundLocation
 from .domain import CreateFloatingIPResponse, FloatingIP
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ class BoundFloatingIP(BoundModelBase):
     model = FloatingIP
 
     def __init__(self, client, data, complete=True):
-        from ..servers.client import BoundServer
+        from ..servers import BoundServer
 
         server = data.get("server")
         if server is not None:

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from ..locations import BoundLocation
 from .domain import CreateFloatingIPResponse, FloatingIP
 

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class FloatingIP(BaseDomain):

--- a/hcloud/helpers/__init__.py
+++ b/hcloud/helpers/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .labels import LabelValidator  # noqa: F401

--- a/hcloud/images/__init__.py
+++ b/hcloud/images/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundImage, ImagesClient, ImagesPageResult  # noqa: F401
+from .domain import CreateImageResponse, Image  # noqa: F401

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import Image
 
 if TYPE_CHECKING:

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import Image
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ class BoundImage(BoundModelBase):
     model = Image
 
     def __init__(self, client, data):
-        from ..servers.client import BoundServer
+        from ..servers import BoundServer
 
         created_from = data.get("created_from")
         if created_from is not None:

--- a/hcloud/images/domain.py
+++ b/hcloud/images/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class Image(BaseDomain, DomainIdentityMixin):

--- a/hcloud/isos/__init__.py
+++ b/hcloud/isos/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundIso, IsosClient, IsosPageResult  # noqa: F401
+from .domain import Iso  # noqa: F401

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 from warnings import warn
 
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import Iso
 
 if TYPE_CHECKING:

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 from warnings import warn
 
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import Iso
 
 if TYPE_CHECKING:

--- a/hcloud/isos/domain.py
+++ b/hcloud/isos/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class Iso(BaseDomain, DomainIdentityMixin):

--- a/hcloud/load_balancer_types/__init__.py
+++ b/hcloud/load_balancer_types/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundLoadBalancerType,
+    LoadBalancerTypesClient,
+    LoadBalancerTypesPageResult,
+)
+from .domain import LoadBalancerType  # noqa: F401

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import LoadBalancerType
 
 if TYPE_CHECKING:

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import LoadBalancerType
 
 if TYPE_CHECKING:

--- a/hcloud/load_balancer_types/domain.py
+++ b/hcloud/load_balancer_types/domain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class LoadBalancerType(BaseDomain, DomainIdentityMixin):

--- a/hcloud/load_balancers/__init__.py
+++ b/hcloud/load_balancers/__init__.py
@@ -9,6 +9,7 @@ from .domain import (  # noqa: F401
     CreateLoadBalancerResponse,
     IPv4Address,
     IPv6Network,
+    LoadBalancer,
     LoadBalancerAlgorithm,
     LoadBalancerHealtCheckHttp,
     LoadBalancerHealthCheck,

--- a/hcloud/load_balancers/__init__.py
+++ b/hcloud/load_balancers/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundLoadBalancer,
+    LoadBalancersClient,
+    LoadBalancersPageResult,
+)
+from .domain import (  # noqa: F401
+    CreateLoadBalancerResponse,
+    IPv4Address,
+    IPv6Network,
+    LoadBalancerAlgorithm,
+    LoadBalancerHealtCheckHttp,
+    LoadBalancerHealthCheck,
+    LoadBalancerService,
+    LoadBalancerServiceHttp,
+    LoadBalancerTarget,
+    LoadBalancerTargetIP,
+    LoadBalancerTargetLabelSelector,
+    PrivateNet,
+    PublicNetwork,
+)

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -4,8 +4,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
 from ..certificates import BoundCertificate
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from ..load_balancer_types import BoundLoadBalancerType
 from ..locations import BoundLocation
 from ..networks import BoundNetwork

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..certificates.client import BoundCertificate
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
-from ..load_balancer_types.client import BoundLoadBalancerType
-from ..locations.client import BoundLocation
-from ..networks.client import BoundNetwork
-from ..servers.client import BoundServer
+from ..actions import ActionsPageResult, BoundAction
+from ..certificates import BoundCertificate
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
+from ..load_balancer_types import BoundLoadBalancerType
+from ..locations import BoundLocation
+from ..networks import BoundNetwork
+from ..servers import BoundServer
 from .domain import (
     CreateLoadBalancerResponse,
     IPv4Address,

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class LoadBalancer(BaseDomain):

--- a/hcloud/locations/__init__.py
+++ b/hcloud/locations/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundLocation, LocationsClient, LocationsPageResult  # noqa: F401
+from .domain import Location  # noqa: F401

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import Location
 
 if TYPE_CHECKING:

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import Location
 
 if TYPE_CHECKING:

--- a/hcloud/locations/domain.py
+++ b/hcloud/locations/domain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class Location(BaseDomain, DomainIdentityMixin):

--- a/hcloud/networks/__init__.py
+++ b/hcloud/networks/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .client import BoundNetwork, NetworksClient, NetworksPageResult  # noqa: F401
+from .domain import (  # noqa: F401
+    CreateNetworkResponse,
+    Network,
+    NetworkRoute,
+    NetworkSubnet,
+)

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import Network, NetworkRoute, NetworkSubnet
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ class BoundNetwork(BoundModelBase):
             routes = [NetworkRoute.from_dict(route) for route in routes]
             data["routes"] = routes
 
-        from ..servers.client import BoundServer
+        from ..servers import BoundServer
 
         servers = data.get("servers", [])
         if servers is not None:

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import Network, NetworkRoute, NetworkSubnet
 
 if TYPE_CHECKING:

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class Network(BaseDomain):

--- a/hcloud/placement_groups/__init__.py
+++ b/hcloud/placement_groups/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundPlacementGroup,
+    PlacementGroupsClient,
+    PlacementGroupsPageResult,
+)
+from .domain import CreatePlacementGroupResponse, PlacementGroup  # noqa: F401

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import CreatePlacementGroupResponse, PlacementGroup
 
 if TYPE_CHECKING:

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..actions import BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import CreatePlacementGroupResponse, PlacementGroup
 
 if TYPE_CHECKING:

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class PlacementGroup(BaseDomain):

--- a/hcloud/primary_ips/__init__.py
+++ b/hcloud/primary_ips/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundPrimaryIP, PrimaryIPsClient, PrimaryIPsPageResult  # noqa: F401
+from .domain import CreatePrimaryIPResponse, PrimaryIP  # noqa: F401

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..actions import BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import CreatePrimaryIPResponse, PrimaryIP
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ class BoundPrimaryIP(BoundModelBase):
     model = PrimaryIP
 
     def __init__(self, client, data, complete=True):
-        from ..datacenters.client import BoundDatacenter
+        from ..datacenters import BoundDatacenter
 
         datacenter = data.get("datacenter", {})
         if datacenter:

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import CreatePrimaryIPResponse, PrimaryIP
 
 if TYPE_CHECKING:

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class PrimaryIP(BaseDomain):

--- a/hcloud/server_types/__init__.py
+++ b/hcloud/server_types/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .client import (  # noqa: F401
+    BoundServerType,
+    ServerTypesClient,
+    ServerTypesPageResult,
+)
+from .domain import ServerType  # noqa: F401

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import ServerType
 
 if TYPE_CHECKING:

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import ServerType
 
 if TYPE_CHECKING:

--- a/hcloud/server_types/domain.py
+++ b/hcloud/server_types/domain.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
-from ..deprecation.domain import DeprecationInfo
+from ..core import BaseDomain, DomainIdentityMixin
+from ..deprecation import DeprecationInfo
 
 
 class ServerType(BaseDomain, DomainIdentityMixin):

--- a/hcloud/servers/__init__.py
+++ b/hcloud/servers/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .client import BoundServer, ServersClient, ServersPageResult  # noqa: F401
+from .domain import (  # noqa: F401
+    CreateServerResponse,
+    EnableRescueResponse,
+    IPv4Address,
+    IPv6Network,
+    PrivateNet,
+    PublicNetwork,
+    PublicNetworkFirewall,
+    RequestConsoleResponse,
+    ResetPasswordResponse,
+    ServerCreatePublicNetwork,
+)

--- a/hcloud/servers/__init__.py
+++ b/hcloud/servers/__init__.py
@@ -11,5 +11,6 @@ from .domain import (  # noqa: F401
     PublicNetworkFirewall,
     RequestConsoleResponse,
     ResetPasswordResponse,
+    Server,
     ServerCreatePublicNetwork,
 )

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from ..datacenters import BoundDatacenter
 from ..firewalls import BoundFirewall
 from ..floating_ips import BoundFloatingIP
-from ..images import BoundImage
-from ..images import CreateImageResponse
+from ..images import BoundImage, CreateImageResponse
 from ..isos import BoundIso
 from ..networks import BoundNetwork  # noqa
 from ..networks import Network  # noqa

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
-from ..datacenters.client import BoundDatacenter
-from ..firewalls.client import BoundFirewall
-from ..floating_ips.client import BoundFloatingIP
-from ..images.client import BoundImage
-from ..images.domain import CreateImageResponse
-from ..isos.client import BoundIso
-from ..networks.client import BoundNetwork  # noqa
-from ..networks.domain import Network  # noqa
-from ..placement_groups.client import BoundPlacementGroup
-from ..primary_ips.client import BoundPrimaryIP
-from ..server_types.client import BoundServerType
-from ..volumes.client import BoundVolume
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
+from ..datacenters import BoundDatacenter
+from ..firewalls import BoundFirewall
+from ..floating_ips import BoundFloatingIP
+from ..images import BoundImage
+from ..images import CreateImageResponse
+from ..isos import BoundIso
+from ..networks import BoundNetwork  # noqa
+from ..networks import Network  # noqa
+from ..placement_groups import BoundPlacementGroup
+from ..primary_ips import BoundPrimaryIP
+from ..server_types import BoundServerType
+from ..volumes import BoundVolume
 from .domain import (
     CreateServerResponse,
     EnableRescueResponse,

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain
+from ..core import BaseDomain
 
 
 class Server(BaseDomain):

--- a/hcloud/ssh_keys/__init__.py
+++ b/hcloud/ssh_keys/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundSSHKey, SSHKeysClient, SSHKeysPageResult  # noqa: F401
+from .domain import SSHKey  # noqa: F401

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
 from .domain import SSHKey
 
 if TYPE_CHECKING:

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from .domain import SSHKey
 
 if TYPE_CHECKING:

--- a/hcloud/ssh_keys/domain.py
+++ b/hcloud/ssh_keys/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class SSHKey(BaseDomain, DomainIdentityMixin):

--- a/hcloud/volumes/__init__.py
+++ b/hcloud/volumes/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .client import BoundVolume, VolumesClient, VolumesPageResult  # noqa: F401
+from .domain import CreateVolumeResponse, Volume  # noqa: F401

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 from ..actions import ActionsPageResult, BoundAction
-from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core import Meta
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin, Meta
 from ..locations import BoundLocation
 from .domain import CreateVolumeResponse, Volume
 

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
-from ..actions.client import ActionsPageResult, BoundAction
-from ..core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from ..core.domain import Meta
-from ..locations.client import BoundLocation
+from ..actions import ActionsPageResult, BoundAction
+from ..core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from ..core import Meta
+from ..locations import BoundLocation
 from .domain import CreateVolumeResponse, Volume
 
 if TYPE_CHECKING:
@@ -22,7 +22,7 @@ class BoundVolume(BoundModelBase):
         if location is not None:
             data["location"] = BoundLocation(client._client.locations, location)
 
-        from ..servers.client import BoundServer
+        from ..servers import BoundServer
 
         server = data.get("server")
         if server is not None:

--- a/hcloud/volumes/domain.py
+++ b/hcloud/volumes/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dateutil.parser import isoparse
 
-from ..core.domain import BaseDomain, DomainIdentityMixin
+from ..core import BaseDomain, DomainIdentityMixin
 
 
 class Volume(BaseDomain, DomainIdentityMixin):

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -4,8 +4,13 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions import ActionsClient, BoundAction
-from hcloud.actions import Action, ActionFailedException, ActionTimeoutException
+from hcloud.actions import (
+    Action,
+    ActionFailedException,
+    ActionsClient,
+    ActionTimeoutException,
+    BoundAction,
+)
 
 
 class TestBoundAction:

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import ActionsClient, BoundAction
-from hcloud.actions.domain import Action, ActionFailedException, ActionTimeoutException
+from hcloud.actions import ActionsClient, BoundAction
+from hcloud.actions import Action, ActionFailedException, ActionTimeoutException
 
 
 class TestBoundAction:

--- a/tests/unit/actions/test_domain.py
+++ b/tests/unit/actions/test_domain.py
@@ -5,7 +5,7 @@ from datetime import timezone
 
 import pytest
 
-from hcloud.actions.domain import (
+from hcloud.actions import (
     Action,
     ActionException,
     ActionFailedException,

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -4,9 +4,9 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import BoundAction
-from hcloud.certificates.client import BoundCertificate, CertificatesClient
-from hcloud.certificates.domain import Certificate, ManagedCertificateStatus
+from hcloud.actions import BoundAction
+from hcloud.certificates import BoundCertificate, CertificatesClient
+from hcloud.certificates import Certificate, ManagedCertificateStatus
 
 
 class TestBoundCertificate:

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -5,8 +5,12 @@ from unittest import mock
 import pytest
 
 from hcloud.actions import BoundAction
-from hcloud.certificates import BoundCertificate, CertificatesClient
-from hcloud.certificates import Certificate, ManagedCertificateStatus
+from hcloud.certificates import (
+    BoundCertificate,
+    Certificate,
+    CertificatesClient,
+    ManagedCertificateStatus,
+)
 
 
 class TestBoundCertificate:

--- a/tests/unit/certificates/test_domain.py
+++ b/tests/unit/certificates/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.certificates.domain import Certificate
+from hcloud.certificates import Certificate
 
 
 class TestCertificate:

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -5,9 +5,9 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import ActionsPageResult
-from hcloud.core.client import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core.domain import BaseDomain, Meta
+from hcloud.actions import ActionsPageResult
+from hcloud.core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
+from hcloud.core import BaseDomain, Meta
 
 
 class TestBoundModelBase:

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -6,8 +6,13 @@ from unittest import mock
 import pytest
 
 from hcloud.actions import ActionsPageResult
-from hcloud.core import BoundModelBase, ClientEntityBase, GetEntityByNameMixin
-from hcloud.core import BaseDomain, Meta
+from hcloud.core import (
+    BaseDomain,
+    BoundModelBase,
+    ClientEntityBase,
+    GetEntityByNameMixin,
+    Meta,
+)
 
 
 class TestBoundModelBase:

--- a/tests/unit/core/test_domain.py
+++ b/tests/unit/core/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from dateutil.parser import isoparse
 
-from hcloud.core.domain import BaseDomain, DomainIdentityMixin, Meta, Pagination
+from hcloud.core import BaseDomain, DomainIdentityMixin, Meta, Pagination
 
 
 class TestMeta:

--- a/tests/unit/datacenters/test_client.py
+++ b/tests/unit/datacenters/test_client.py
@@ -4,8 +4,7 @@ from unittest import mock  # noqa: F401
 
 import pytest  # noqa: F401
 
-from hcloud.datacenters import BoundDatacenter, DatacentersClient
-from hcloud.datacenters import DatacenterServerTypes
+from hcloud.datacenters import BoundDatacenter, DatacentersClient, DatacenterServerTypes
 from hcloud.locations import BoundLocation
 
 

--- a/tests/unit/datacenters/test_client.py
+++ b/tests/unit/datacenters/test_client.py
@@ -4,9 +4,9 @@ from unittest import mock  # noqa: F401
 
 import pytest  # noqa: F401
 
-from hcloud.datacenters.client import BoundDatacenter, DatacentersClient
-from hcloud.datacenters.domain import DatacenterServerTypes
-from hcloud.locations.client import BoundLocation
+from hcloud.datacenters import BoundDatacenter, DatacentersClient
+from hcloud.datacenters import DatacenterServerTypes
+from hcloud.locations import BoundLocation
 
 
 class TestBoundDatacenter:

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -4,15 +4,15 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import BoundAction
-from hcloud.firewalls.client import BoundFirewall, FirewallsClient
-from hcloud.firewalls.domain import (
+from hcloud.actions import BoundAction
+from hcloud.firewalls import BoundFirewall, FirewallsClient
+from hcloud.firewalls import (
     Firewall,
     FirewallResource,
     FirewallResourceLabelSelector,
     FirewallRule,
 )
-from hcloud.servers.domain import Server
+from hcloud.servers import Server
 
 
 class TestBoundFirewall:

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -5,12 +5,13 @@ from unittest import mock
 import pytest
 
 from hcloud.actions import BoundAction
-from hcloud.firewalls import BoundFirewall, FirewallsClient
 from hcloud.firewalls import (
+    BoundFirewall,
     Firewall,
     FirewallResource,
     FirewallResourceLabelSelector,
     FirewallRule,
+    FirewallsClient,
 )
 from hcloud.servers import Server
 

--- a/tests/unit/firewalls/test_domain.py
+++ b/tests/unit/firewalls/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.firewalls.domain import Firewall
+from hcloud.firewalls import Firewall
 
 
 class TestFirewall:

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -4,13 +4,13 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import BoundAction
-from hcloud.floating_ips.client import BoundFloatingIP, FloatingIPsClient
-from hcloud.floating_ips.domain import FloatingIP
-from hcloud.locations.client import BoundLocation
-from hcloud.locations.domain import Location
-from hcloud.servers.client import BoundServer
-from hcloud.servers.domain import Server
+from hcloud.actions import BoundAction
+from hcloud.floating_ips import BoundFloatingIP, FloatingIPsClient
+from hcloud.floating_ips import FloatingIP
+from hcloud.locations import BoundLocation
+from hcloud.locations import Location
+from hcloud.servers import BoundServer
+from hcloud.servers import Server
 
 
 class TestBoundFloatingIP:

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -5,12 +5,9 @@ from unittest import mock
 import pytest
 
 from hcloud.actions import BoundAction
-from hcloud.floating_ips import BoundFloatingIP, FloatingIPsClient
-from hcloud.floating_ips import FloatingIP
-from hcloud.locations import BoundLocation
-from hcloud.locations import Location
-from hcloud.servers import BoundServer
-from hcloud.servers import Server
+from hcloud.floating_ips import BoundFloatingIP, FloatingIP, FloatingIPsClient
+from hcloud.locations import BoundLocation, Location
+from hcloud.servers import BoundServer, Server
 
 
 class TestBoundFloatingIP:

--- a/tests/unit/floating_ips/test_domain.py
+++ b/tests/unit/floating_ips/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.floating_ips.domain import FloatingIP
+from hcloud.floating_ips import FloatingIP
 
 
 class TestFloatingIP:

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -6,10 +6,10 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import BoundAction
-from hcloud.images.client import BoundImage, ImagesClient
-from hcloud.images.domain import Image
-from hcloud.servers.client import BoundServer
+from hcloud.actions import BoundAction
+from hcloud.images import BoundImage, ImagesClient
+from hcloud.images import Image
+from hcloud.servers import BoundServer
 
 
 class TestBoundImage:

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -7,8 +7,7 @@ from unittest import mock
 import pytest
 
 from hcloud.actions import BoundAction
-from hcloud.images import BoundImage, ImagesClient
-from hcloud.images import Image
+from hcloud.images import BoundImage, Image, ImagesClient
 from hcloud.servers import BoundServer
 
 

--- a/tests/unit/images/test_domain.py
+++ b/tests/unit/images/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.images.domain import Image
+from hcloud.images import Image
 
 
 class TestImage:

--- a/tests/unit/isos/test_client.py
+++ b/tests/unit/isos/test_client.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from hcloud.isos.client import BoundIso, IsosClient
+from hcloud.isos import BoundIso, IsosClient
 
 
 class TestBoundIso:

--- a/tests/unit/isos/test_domain.py
+++ b/tests/unit/isos/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.isos.domain import Iso
+from hcloud.isos import Iso
 
 
 class TestIso:

--- a/tests/unit/load_balancer_types/test_client.py
+++ b/tests/unit/load_balancer_types/test_client.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from hcloud.load_balancer_types.client import LoadBalancerTypesClient
+from hcloud.load_balancer_types import LoadBalancerTypesClient
 
 
 class TestLoadBalancerTypesClient:

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -6,11 +6,12 @@ import pytest
 
 from hcloud.actions import BoundAction
 from hcloud.load_balancer_types import LoadBalancerType
-from hcloud.load_balancers import BoundLoadBalancer, LoadBalancersClient
 from hcloud.load_balancers import (
+    BoundLoadBalancer,
     LoadBalancer,
     LoadBalancerAlgorithm,
     LoadBalancerHealthCheck,
+    LoadBalancersClient,
     LoadBalancerService,
     LoadBalancerTarget,
     LoadBalancerTargetIP,

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -4,10 +4,10 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import BoundAction
-from hcloud.load_balancer_types.domain import LoadBalancerType
-from hcloud.load_balancers.client import BoundLoadBalancer, LoadBalancersClient
-from hcloud.load_balancers.domain import (
+from hcloud.actions import BoundAction
+from hcloud.load_balancer_types import LoadBalancerType
+from hcloud.load_balancers import BoundLoadBalancer, LoadBalancersClient
+from hcloud.load_balancers import (
     LoadBalancer,
     LoadBalancerAlgorithm,
     LoadBalancerHealthCheck,
@@ -16,9 +16,9 @@ from hcloud.load_balancers.domain import (
     LoadBalancerTargetIP,
     LoadBalancerTargetLabelSelector,
 )
-from hcloud.locations.domain import Location
-from hcloud.networks.domain import Network
-from hcloud.servers.domain import Server
+from hcloud.locations import Location
+from hcloud.networks import Network
+from hcloud.servers import Server
 
 
 class TestBoundLoadBalancer:

--- a/tests/unit/load_balancers/test_domain.py
+++ b/tests/unit/load_balancers/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.load_balancers.domain import LoadBalancer
+from hcloud.load_balancers import LoadBalancer
 
 
 class TestLoadBalancers:

--- a/tests/unit/locations/test_client.py
+++ b/tests/unit/locations/test_client.py
@@ -4,7 +4,7 @@ from unittest import mock  # noqa: F401
 
 import pytest  # noqa: F401
 
-from hcloud.locations.client import LocationsClient
+from hcloud.locations import LocationsClient
 
 
 class TestLocationsClient:

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -5,10 +5,10 @@ from unittest import mock
 import pytest
 from dateutil.parser import isoparse
 
-from hcloud.actions.client import BoundAction
-from hcloud.networks.client import BoundNetwork, NetworksClient
-from hcloud.networks.domain import Network, NetworkRoute, NetworkSubnet
-from hcloud.servers.client import BoundServer
+from hcloud.actions import BoundAction
+from hcloud.networks import BoundNetwork, NetworksClient
+from hcloud.networks import Network, NetworkRoute, NetworkSubnet
+from hcloud.servers import BoundServer
 
 
 class TestBoundNetwork:

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -6,8 +6,13 @@ import pytest
 from dateutil.parser import isoparse
 
 from hcloud.actions import BoundAction
-from hcloud.networks import BoundNetwork, NetworksClient
-from hcloud.networks import Network, NetworkRoute, NetworkSubnet
+from hcloud.networks import (
+    BoundNetwork,
+    Network,
+    NetworkRoute,
+    NetworksClient,
+    NetworkSubnet,
+)
 from hcloud.servers import BoundServer
 
 

--- a/tests/unit/networks/test_domain.py
+++ b/tests/unit/networks/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.networks.domain import Network
+from hcloud.networks import Network
 
 
 class TestNetwork:

--- a/tests/unit/placement_groups/test_client.py
+++ b/tests/unit/placement_groups/test_client.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from hcloud.placement_groups.client import BoundPlacementGroup, PlacementGroupsClient
+from hcloud.placement_groups import BoundPlacementGroup, PlacementGroupsClient
 
 
 def check_variables(placement_group, expected):

--- a/tests/unit/placement_groups/test_domain.py
+++ b/tests/unit/placement_groups/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.placement_groups.domain import PlacementGroup
+from hcloud.placement_groups import PlacementGroup
 
 
 class TestPlacementGroup:

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -4,10 +4,10 @@ from unittest import mock
 
 import pytest
 
-from hcloud.datacenters.client import BoundDatacenter
-from hcloud.datacenters.domain import Datacenter
-from hcloud.primary_ips.client import BoundPrimaryIP, PrimaryIPsClient
-from hcloud.primary_ips.domain import PrimaryIP
+from hcloud.datacenters import BoundDatacenter
+from hcloud.datacenters import Datacenter
+from hcloud.primary_ips import BoundPrimaryIP, PrimaryIPsClient
+from hcloud.primary_ips import PrimaryIP
 
 
 class TestBoundPrimaryIP:

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -4,10 +4,8 @@ from unittest import mock
 
 import pytest
 
-from hcloud.datacenters import BoundDatacenter
-from hcloud.datacenters import Datacenter
-from hcloud.primary_ips import BoundPrimaryIP, PrimaryIPsClient
-from hcloud.primary_ips import PrimaryIP
+from hcloud.datacenters import BoundDatacenter, Datacenter
+from hcloud.primary_ips import BoundPrimaryIP, PrimaryIP, PrimaryIPsClient
 
 
 class TestBoundPrimaryIP:

--- a/tests/unit/primary_ips/test_domain.py
+++ b/tests/unit/primary_ips/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.primary_ips.domain import PrimaryIP
+from hcloud.primary_ips import PrimaryIP
 
 
 class TestPrimaryIP:

--- a/tests/unit/server_types/test_client.py
+++ b/tests/unit/server_types/test_client.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from hcloud.server_types.client import BoundServerType, ServerTypesClient
+from hcloud.server_types import BoundServerType, ServerTypesClient
 
 
 class TestBoundServerType:

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -5,33 +5,26 @@ from unittest import mock
 import pytest
 
 from hcloud.actions import BoundAction
-from hcloud.datacenters import BoundDatacenter
-from hcloud.datacenters import Datacenter
-from hcloud.firewalls import BoundFirewall
-from hcloud.firewalls import Firewall
+from hcloud.datacenters import BoundDatacenter, Datacenter
+from hcloud.firewalls import BoundFirewall, Firewall
 from hcloud.floating_ips import BoundFloatingIP
-from hcloud.images import BoundImage
-from hcloud.images import Image
-from hcloud.isos import BoundIso
-from hcloud.isos import Iso
+from hcloud.images import BoundImage, Image
+from hcloud.isos import BoundIso, Iso
 from hcloud.locations import Location
-from hcloud.networks import BoundNetwork
-from hcloud.networks import Network
-from hcloud.placement_groups import BoundPlacementGroup
-from hcloud.placement_groups import PlacementGroup
-from hcloud.server_types import BoundServerType
-from hcloud.server_types import ServerType
-from hcloud.servers import BoundServer, ServersClient
+from hcloud.networks import BoundNetwork, Network
+from hcloud.placement_groups import BoundPlacementGroup, PlacementGroup
+from hcloud.server_types import BoundServerType, ServerType
 from hcloud.servers import (
+    BoundServer,
     IPv4Address,
     IPv6Network,
     PrivateNet,
     PublicNetwork,
     PublicNetworkFirewall,
     Server,
+    ServersClient,
 )
-from hcloud.volumes import BoundVolume
-from hcloud.volumes import Volume
+from hcloud.volumes import BoundVolume, Volume
 
 
 class TestBoundServer:

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -4,25 +4,25 @@ from unittest import mock
 
 import pytest
 
-from hcloud.actions.client import BoundAction
-from hcloud.datacenters.client import BoundDatacenter
-from hcloud.datacenters.domain import Datacenter
-from hcloud.firewalls.client import BoundFirewall
-from hcloud.firewalls.domain import Firewall
-from hcloud.floating_ips.client import BoundFloatingIP
-from hcloud.images.client import BoundImage
-from hcloud.images.domain import Image
-from hcloud.isos.client import BoundIso
-from hcloud.isos.domain import Iso
-from hcloud.locations.domain import Location
-from hcloud.networks.client import BoundNetwork
-from hcloud.networks.domain import Network
-from hcloud.placement_groups.client import BoundPlacementGroup
-from hcloud.placement_groups.domain import PlacementGroup
-from hcloud.server_types.client import BoundServerType
-from hcloud.server_types.domain import ServerType
-from hcloud.servers.client import BoundServer, ServersClient
-from hcloud.servers.domain import (
+from hcloud.actions import BoundAction
+from hcloud.datacenters import BoundDatacenter
+from hcloud.datacenters import Datacenter
+from hcloud.firewalls import BoundFirewall
+from hcloud.firewalls import Firewall
+from hcloud.floating_ips import BoundFloatingIP
+from hcloud.images import BoundImage
+from hcloud.images import Image
+from hcloud.isos import BoundIso
+from hcloud.isos import Iso
+from hcloud.locations import Location
+from hcloud.networks import BoundNetwork
+from hcloud.networks import Network
+from hcloud.placement_groups import BoundPlacementGroup
+from hcloud.placement_groups import PlacementGroup
+from hcloud.server_types import BoundServerType
+from hcloud.server_types import ServerType
+from hcloud.servers import BoundServer, ServersClient
+from hcloud.servers import (
     IPv4Address,
     IPv6Network,
     PrivateNet,
@@ -30,8 +30,8 @@ from hcloud.servers.domain import (
     PublicNetworkFirewall,
     Server,
 )
-from hcloud.volumes.client import BoundVolume
-from hcloud.volumes.domain import Volume
+from hcloud.volumes import BoundVolume
+from hcloud.volumes import Volume
 
 
 class TestBoundServer:

--- a/tests/unit/servers/test_domain.py
+++ b/tests/unit/servers/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.servers.domain import Server
+from hcloud.servers import Server
 
 
 class TestServer:

--- a/tests/unit/ssh_keys/test_client.py
+++ b/tests/unit/ssh_keys/test_client.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 import pytest
 
-from hcloud.ssh_keys.client import BoundSSHKey, SSHKeysClient
-from hcloud.ssh_keys.domain import SSHKey
+from hcloud.ssh_keys import BoundSSHKey, SSHKeysClient
+from hcloud.ssh_keys import SSHKey
 
 
 class TestBoundSSHKey:

--- a/tests/unit/ssh_keys/test_client.py
+++ b/tests/unit/ssh_keys/test_client.py
@@ -4,8 +4,7 @@ from unittest import mock
 
 import pytest
 
-from hcloud.ssh_keys import BoundSSHKey, SSHKeysClient
-from hcloud.ssh_keys import SSHKey
+from hcloud.ssh_keys import BoundSSHKey, SSHKey, SSHKeysClient
 
 
 class TestBoundSSHKey:

--- a/tests/unit/ssh_keys/test_domain.py
+++ b/tests/unit/ssh_keys/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.ssh_keys.domain import SSHKey
+from hcloud.ssh_keys import SSHKey
 
 
 class TestSSHKey:

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -5,13 +5,13 @@ from unittest import mock
 import pytest
 from dateutil.parser import isoparse
 
-from hcloud.actions.client import BoundAction
-from hcloud.locations.client import BoundLocation
-from hcloud.locations.domain import Location
-from hcloud.servers.client import BoundServer
-from hcloud.servers.domain import Server
-from hcloud.volumes.client import BoundVolume, VolumesClient
-from hcloud.volumes.domain import Volume
+from hcloud.actions import BoundAction
+from hcloud.locations import BoundLocation
+from hcloud.locations import Location
+from hcloud.servers import BoundServer
+from hcloud.servers import Server
+from hcloud.volumes import BoundVolume, VolumesClient
+from hcloud.volumes import Volume
 
 
 class TestBoundVolume:

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -6,12 +6,9 @@ import pytest
 from dateutil.parser import isoparse
 
 from hcloud.actions import BoundAction
-from hcloud.locations import BoundLocation
-from hcloud.locations import Location
-from hcloud.servers import BoundServer
-from hcloud.servers import Server
-from hcloud.volumes import BoundVolume, VolumesClient
-from hcloud.volumes import Volume
+from hcloud.locations import BoundLocation, Location
+from hcloud.servers import BoundServer, Server
+from hcloud.volumes import BoundVolume, Volume, VolumesClient
 
 
 class TestBoundVolume:

--- a/tests/unit/volumes/test_domain.py
+++ b/tests/unit/volumes/test_domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timezone
 
-from hcloud.volumes.domain import Volume
+from hcloud.volumes import Volume
 
 
 class TestVolume:


### PR DESCRIPTION
This reexport the references inside `{ressource}.client` and `{ressource}.domain` inside `{ressource}`.

This allows for smaller imports lines, and also a clear definition of what is "public" and what is not.