### PR TITLE
chore: fix package included files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,10 @@
+include CHANGELOG.md
 include CONTRIBUTING.rst
-include CHANGELOG.rst
 include LICENSE
-include README.rst
+include README.md
 
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif *.js *.svg
+recursive-include docs conf.py Makefile make.bat *.rst *.md *.jpg *.png *.gif *.js *.svg

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from setuptools import find_packages, setup
 
-with open("README.md") as readme_file:
+with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 version = {}
-with open("hcloud/__version__.py") as fp:
+with open("hcloud/__version__.py", encoding="utf-8") as fp:
     exec(fp.read(), version)
 
 setup(
@@ -57,6 +57,6 @@ setup(
         ],
     },
     include_package_data=True,
-    packages=find_packages(exclude=["examples", "tests*", "docs"]),
+    packages=find_packages(),
     zip_safe=False,
 )


### PR DESCRIPTION
The previously used filename were pointed to invalid names. Fix some linting errors and duplication.