### PR TITLE
ci: fix gitlab lint job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ lint:
 
   image: python:3.11-alpine
   before_script:
+    - apk add make
     - make venv
   script:
     - make lint


### PR DESCRIPTION
`make` is missing from the default python alpine images
