### PR TITLE
docs: fix python references

### DIFF
--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -81,7 +81,7 @@ class BoundCertificate(BoundModelBase):
                New name to set
         :param labels: Dict[str, str] (optional)
                User-defined labels (key-value pairs)
-        :return: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>
+        :return: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>`
         """
         return self._client.update(self, name, labels)
 

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -46,13 +46,13 @@ class BoundFloatingIP(BoundModelBase):
 
         :param status: List[str] (optional)
                 Response will have only actions with specified statuses. Choices: `running` `success` `error`
-         :param sort: List[str] (optional)
+        :param sort: List[str] (optional)
                 Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
-         :param page: int (optional)
+        :param page: int (optional)
                 Specifies the page to fetch
-         :param per_page: int (optional)
+        :param per_page: int (optional)
                 Specifies how many results are returned by page
-         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
+        :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
         return self._client.get_actions_list(self, status, sort, page, per_page)
 
@@ -67,7 +67,6 @@ class BoundFloatingIP(BoundModelBase):
                Response will have only actions with specified statuses. Choices: `running` `success` `error`
         :param sort: List[str] (optional)
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
-
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
         return self._client.get_actions(self, status, sort)

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -180,7 +180,7 @@ class ImagesClient(ClientEntityBase):
         """Get a specific Image
 
         :param id: int
-        :return: :class:`BoundImage <hcloud.images.client.BoundImage
+        :return: :class:`BoundImage <hcloud.images.client.BoundImage`
         """
         response = self._client.request(url=f"/images/{id}", method="GET")
         return BoundImage(self, response["image"])

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -172,7 +172,7 @@ class NetworksClient(ClientEntityBase):
         """Get a specific network
 
         :param id: int
-        :return: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>
+        :return: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>`
         """
         response = self._client.request(url=f"/networks/{id}", method="GET")
         return BoundNetwork(self, response["network"])

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -25,7 +25,7 @@ class BoundSSHKey(BoundModelBase):
                New Description to set
         :param labels: Dict[str, str] (optional)
                User-defined labels (key-value pairs)
-        :return: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>
+        :return: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>`
         """
         return self._client.update(self, name, labels)
 

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -62,7 +62,7 @@ class BoundVolume(BoundModelBase):
 
         :param status: List[str] (optional)
                Response will have only actions with specified statuses. Choices: `running` `success` `error`
-        :param sort:List[str] (optional)
+        :param sort: List[str] (optional)
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
@@ -325,7 +325,7 @@ class VolumesClient(ClientEntityBase):
         :param volume: :class:`BoundVolume <hcloud.volumes.client.BoundVolume>` or :class:`Volume <hcloud.volumes.domain.Volume>`
         :param status: List[str] (optional)
                Response will have only actions with specified statuses. Choices: `running` `success` `error`
-        :param sort:List[str] (optional)
+        :param sort: List[str] (optional)
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """


### PR DESCRIPTION
This fixes the warnings raised by sphinx during the build process. Some rst directives / python references were broken.