### PR TITLE
build: exclude top-level directories from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setup(
         ],
     },
     include_package_data=True,
-    packages=find_packages(exclude=["tests*"]),
+    packages=find_packages(exclude=["examples", "tests*", "docs"]),
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setup(
         ],
     },
     include_package_data=True,
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     zip_safe=False,
 )


### PR DESCRIPTION
Fix `setup.py` to exclude installing the `tests`, `examples` and `docs` directories as a top-level Python package, i.e. into:

```
/usr/lib/python*/site-packages/tests
```

Related to 68bb0f2bf33df5e12607b94a306f5ec328685c44