### PR TITLE
ci: explicitly declare pre-commit job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,9 @@ include:
 stages:
   - test
 
+pre-commit:
+  extends: [.pre-commit]
+
 lint:
   stage: test
 


### PR DESCRIPTION
The pre-commit template does not set the job automatically.