### PR TITLE
feat: add domain attribute type hints to bound models

### DIFF
--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundAction(BoundModelBase):
+class BoundAction(BoundModelBase, Action):
     _client: ActionsClient
 
     model = Action

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundCertificate(BoundModelBase):
+class BoundCertificate(BoundModelBase, Certificate):
     _client: CertificatesClient
 
     model = Certificate

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundDatacenter(BoundModelBase):
+class BoundDatacenter(BoundModelBase, Datacenter):
     _client: DatacentersClient
 
     model = Datacenter

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundFirewall(BoundModelBase):
+class BoundFirewall(BoundModelBase, Firewall):
     _client: FirewallsClient
 
     model = Firewall

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ..servers import BoundServer, Server
 
 
-class BoundFloatingIP(BoundModelBase):
+class BoundFloatingIP(BoundModelBase, FloatingIP):
     _client: FloatingIPsClient
 
     model = FloatingIP

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundImage(BoundModelBase):
+class BoundImage(BoundModelBase, Image):
     _client: ImagesClient
 
     model = Image

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundIso(BoundModelBase):
+class BoundIso(BoundModelBase, Iso):
     _client: IsosClient
 
     model = Iso

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundLoadBalancerType(BoundModelBase):
+class BoundLoadBalancerType(BoundModelBase, LoadBalancerType):
     _client: LoadBalancerTypesClient
 
     model = LoadBalancerType

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from ..networks import Network
 
 
-class BoundLoadBalancer(BoundModelBase):
+class BoundLoadBalancer(BoundModelBase, LoadBalancer):
     _client: LoadBalancersClient
 
     model = LoadBalancer

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundLocation(BoundModelBase):
+class BoundLocation(BoundModelBase, Location):
     _client: LocationsClient
 
     model = Location

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundNetwork(BoundModelBase):
+class BoundNetwork(BoundModelBase, Network):
     _client: NetworksClient
 
     model = Network

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundPlacementGroup(BoundModelBase):
+class BoundPlacementGroup(BoundModelBase, PlacementGroup):
     _client: PlacementGroupsClient
 
     model = PlacementGroup

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ..datacenters import BoundDatacenter, Datacenter
 
 
-class BoundPrimaryIP(BoundModelBase):
+class BoundPrimaryIP(BoundModelBase, PrimaryIP):
     _client: PrimaryIPsClient
 
     model = PrimaryIP

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundServerType(BoundModelBase):
+class BoundServerType(BoundModelBase, ServerType):
     _client: ServerTypesClient
 
     model = ServerType

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from .domain import ServerCreatePublicNetwork
 
 
-class BoundServer(BoundModelBase):
+class BoundServer(BoundModelBase, Server):
     _client: ServersClient
 
     model = Server

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .._client import Client
 
 
-class BoundSSHKey(BoundModelBase):
+class BoundSSHKey(BoundModelBase, SSHKey):
     _client: SSHKeysClient
 
     model = SSHKey

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ..servers import BoundServer, Server
 
 
-class BoundVolume(BoundModelBase):
+class BoundVolume(BoundModelBase, Volume):
     _client: VolumesClient
 
     model = Volume

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -20,7 +20,7 @@ class TestBoundModelBase:
                 self.name = name
                 self.description = description
 
-        class BoundModel(BoundModelBase):
+        class BoundModel(BoundModelBase, Model):
             model = Model
 
         return BoundModel


### PR DESCRIPTION
This adds the related domain classes as mixins to the bound models.

Provides attributes type hints and the methods of the domain class to the bound model.