### PR TITLE
docs: load token from env in examples scripts

### DIFF
--- a/examples/create_server.py
+++ b/examples/create_server.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from os import environ
+
 from hcloud import Client
 from hcloud.images import Image
 from hcloud.server_types import ServerType
 
-# Please paste your API token here between the quotes
-client = Client(token="{YOUR_API_TOKEN}")
+assert (
+    "HCLOUD_TOKEN" in environ
+), "Please export your API token in the HCLOUD_TOKEN environment variable"
+token = environ["HCLOUD_TOKEN"]
+
+client = Client(token=token)
+
 response = client.servers.create(
     name="my-server",
     server_type=ServerType("cx11"),

--- a/examples/list_servers.py
+++ b/examples/list_servers.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from os import environ
+
 from hcloud import Client
 
-client = Client(
-    token="{YOUR_API_TOKEN}"
-)  # Please paste your API token here between the quotes
+assert (
+    "HCLOUD_TOKEN" in environ
+), "Please export your API token in the HCLOUD_TOKEN environment variable"
+token = environ["HCLOUD_TOKEN"]
+
+client = Client(token=token)
 servers = client.servers.get_all()
 print(servers)

--- a/examples/usage_oop.py
+++ b/examples/usage_oop.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from os import environ
+
 from hcloud import Client
 from hcloud.images import Image
 from hcloud.server_types import ServerType
 
+assert (
+    "HCLOUD_TOKEN" in environ
+), "Please export your API token in the HCLOUD_TOKEN environment variable"
+token = environ["HCLOUD_TOKEN"]
+
 # Create a client
-client = Client(token="project-token")
+client = Client(token=token)
 
 # Create 2 servers
 # Create 2 servers

--- a/examples/usage_procedurale.py
+++ b/examples/usage_procedurale.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+from os import environ
+
 from hcloud import Client
 from hcloud.images import Image
 from hcloud.server_types import ServerType
 from hcloud.servers import Server
 from hcloud.volumes import Volume
 
-client = Client(token="project-token")
+assert (
+    "HCLOUD_TOKEN" in environ
+), "Please export your API token in the HCLOUD_TOKEN environment variable"
+token = environ["HCLOUD_TOKEN"]
+
+client = Client(token=token)
 
 # Create 2 servers
 response1 = client.servers.create(


### PR DESCRIPTION
This allows to run the examples without doing too much copy pasting.