### PR TITLE
fix: prevent api calls when printing bound models

### DIFF
--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -90,3 +90,9 @@ class BoundModelBase:
         bound_model = self._client.get_by_id(self.data_model.id)
         self.data_model = bound_model.data_model
         self.complete = True
+
+    def __repr__(self) -> str:
+        # Override and reset hcloud.core.domain.BaseDomain.__repr__ method for bound
+        # models, as they will generate a lot of API call trying to print all the fields
+        # of the model.
+        return object.__repr__(self)


### PR DESCRIPTION
On large objects such as servers, we might generate more than 10 API calls just to print a single server object. This is because the `__repr__` method will recursively generate the `__repr__` for each bound model property and will trigger a `reload` on incomplete models to gather the information from the API.

Related to:
- https://github.com/hetznercloud/hcloud-python/commit/4c227659bfb61551e44c41315b135039576960d3
- https://github.com/hetznercloud/hcloud-python/commit/6d46d06c42e2e86e88b32a74d7fbd588911cc8ad

Fixes #304