### PR TITLE
feat: add client `cached_session`

### DIFF
--- a/examples/use_cached_session.py
+++ b/examples/use_cached_session.py
@@ -14,6 +14,6 @@ client = Client(token=token)
 with client.cached_session() as session:
     # This will query the API only once
     for i in range(100):
-        servers = session.locations.get_all()
+        locations = session.locations.get_all()
 
-print(servers)
+print(locations)

--- a/examples/use_cached_session.py
+++ b/examples/use_cached_session.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from os import environ
+
+from hcloud import Client
+
+assert (
+    "HCLOUD_TOKEN" in environ
+), "Please export your API token in the HCLOUD_TOKEN environment variable"
+token = environ["HCLOUD_TOKEN"]
+
+client = Client(token=token)
+
+with client.cached_session() as session:
+    # This will query the API only once
+    for i in range(100):
+        servers = session.locations.get_all()
+
+print(servers)

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -248,7 +248,7 @@ class Client:
         Provide a copy of the :class:`Client <hcloud.Client>` as context manager that
         will cache all GET requests.
 
-        Cached response will not expire automatically, therefor the cached client must
+        Cached response will not expire automatically, therefore the cached client must
         not be used for long living scopes.
         """
         client = copy.deepcopy(self)

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -248,8 +248,8 @@ class Client:
         Provide a copy of the :class:`Client <hcloud.Client>` as context manager that
         will cache all GET requests.
 
-        Cached response will not expire automatically, therefore the cached client must
-        not be used for long living scopes.
+        Cached response will not expire, therefore the cached client must not be used
+        for long living scopes.
         """
         client = copy.deepcopy(self)
         client.session(CachedSession())

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import time
 from contextlib import contextmanager
 from typing import Generator, NoReturn
@@ -251,9 +250,9 @@ class Client:
         Cached response will not expire, therefore the cached client must not be used
         for long living scopes.
         """
-        client = copy.deepcopy(self)
-        client.session(CachedSession())
-        yield client
+        self.session(CachedSession())
+        yield self
+        self.session(requests.Session())
 
 
 class CachedSession(requests.Session):


### PR DESCRIPTION
Use this cached session in short-lived scopes. Prevent calling the API too often when iterating over a list of resource that contains the same objects (e.g. servers with the same network).