### PR TITLE
fix: fallback to error code when message is unset

### DIFF
--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -10,8 +10,8 @@ class HCloudException(Exception):
 class APIException(HCloudException):
     """There was an error while performing an API Request"""
 
-    def __init__(self, code: int | str, message: str, details: Any):
-        super().__init__(message)
+    def __init__(self, code: int | str, message: str | None, details: Any):
+        super().__init__(code if message is None and isinstance(code, str) else message)
         self.code = code
         self.message = message
         self.details = details


### PR DESCRIPTION
When the API return a `server_error`, it may not provide a message. This ensures that we print `server_none` instead of `None` when printing the exception. 