### PR TITLE
fix: invalid type for load balancer private network property

### DIFF
--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -76,7 +76,7 @@ class LoadBalancer(BaseDomain):
         id: int,
         name: str | None = None,
         public_net: PublicNetwork | None = None,
-        private_net: PrivateNet | None = None,
+        private_net: list[PrivateNet] | None = None,
         location: BoundLocation | None = None,
         algorithm: LoadBalancerAlgorithm | None = None,
         services: list[LoadBalancerService] | None = None,


### PR DESCRIPTION
https://docs.hetzner.cloud/#load-balancers-get-a-load-balancer