### PR TITLE
feat: add `has_id_or_name` to `DomainIdentityMixin`

### DIFF
--- a/hcloud/core/domain.py
+++ b/hcloud/core/domain.py
@@ -34,6 +34,24 @@ class DomainIdentityMixin:
             return self.name
         raise ValueError("id or name must be set")
 
+    def has_id_or_name(self, id_or_name: int | str) -> bool:
+        """
+        Return whether this domain has the same id or same name as the other.
+
+        The domain calling this method MUST be a bound domain or be populated, otherwise
+        the the comparison will not work as expected (e.g. the domains are the same but
+        cannot be compared, if one provides only an id and the other only the name).
+        """
+        values: list[int | str] = []
+        if self.id is not None:
+            values.append(self.id)
+        if self.name is not None:
+            values.append(self.name)
+        if not values:
+            raise ValueError("id or name must be set")
+
+        return id_or_name in values
+
 
 class Pagination(BaseDomain):
     __slots__ = (

--- a/hcloud/core/domain.py
+++ b/hcloud/core/domain.py
@@ -39,8 +39,8 @@ class DomainIdentityMixin:
         Return whether this domain has the same id or same name as the other.
 
         The domain calling this method MUST be a bound domain or be populated, otherwise
-        the the comparison will not work as expected (e.g. the domains are the same but
-        cannot be compared, if one provides only an id and the other only the name).
+        the comparison will not work as expected (e.g. the domains are the same but
+        cannot be equal, if one provides an id and the other the name).
         """
         values: list[int | str] = []
         if self.id is not None:

--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .client import BoundFirewall
 
 
-class Firewall(BaseDomain):
+class Firewall(BaseDomain, DomainIdentityMixin):
     """Firewall Domain
 
     :param id: int

--- a/hcloud/floating_ips/domain.py
+++ b/hcloud/floating_ips/domain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .client import BoundFloatingIP
 
 
-class FloatingIP(BaseDomain):
+class FloatingIP(BaseDomain, DomainIdentityMixin):
     """Floating IP Domain
 
     :param id: int

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .client import BoundLoadBalancer
 
 
-class LoadBalancer(BaseDomain):
+class LoadBalancer(BaseDomain, DomainIdentityMixin):
     """LoadBalancer Domain
 
     :param id: int

--- a/hcloud/networks/domain.py
+++ b/hcloud/networks/domain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .client import BoundNetwork
 
 
-class Network(BaseDomain):
+class Network(BaseDomain, DomainIdentityMixin):
     """Network Domain
 
     :param id: int

--- a/hcloud/placement_groups/domain.py
+++ b/hcloud/placement_groups/domain.py
@@ -4,14 +4,14 @@ from typing import TYPE_CHECKING
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
     from .client import BoundPlacementGroup
 
 
-class PlacementGroup(BaseDomain):
+class PlacementGroup(BaseDomain, DomainIdentityMixin):
     """Placement Group Domain
 
     :param id: int

--- a/hcloud/primary_ips/domain.py
+++ b/hcloud/primary_ips/domain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .client import BoundPrimaryIP
 
 
-class PrimaryIP(BaseDomain):
+class PrimaryIP(BaseDomain, DomainIdentityMixin):
     """Primary IP Domain
 
     :param id: int

--- a/hcloud/servers/domain.py
+++ b/hcloud/servers/domain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Literal
 
 from dateutil.parser import isoparse
 
-from ..core import BaseDomain
+from ..core import BaseDomain, DomainIdentityMixin
 
 if TYPE_CHECKING:
     from ..actions import BoundAction
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from .client import BoundServer
 
 
-class Server(BaseDomain):
+class Server(BaseDomain, DomainIdentityMixin):
     """Server Domain
 
     :param id: int

--- a/tests/unit/core/test_domain.py
+++ b/tests/unit/core/test_domain.py
@@ -65,9 +65,24 @@ class TestDomainIdentityMixin:
         domain = SomeDomain()
 
         with pytest.raises(ValueError) as exception_info:
-            domain.id_or_name
+            _ = domain.id_or_name
         error = exception_info.value
         assert str(error) == "id or name must be set"
+
+    @pytest.mark.parametrize(
+        "other, expected",
+        [
+            (SomeDomain(id=1), True),
+            (SomeDomain(name="name1"), True),
+            (SomeDomain(id=1, name="name1"), True),
+            (SomeDomain(id=2), False),
+            (SomeDomain(name="name2"), False),
+            (SomeDomain(id=2, name="name2"), False),
+        ],
+    )
+    def test_has_id_or_name_exception(self, other, expected):
+        domain = SomeDomain(id=1, name="name1")
+        assert domain.has_id_or_name(other.id_or_name) == expected
 
 
 class ActionDomain(BaseDomain, DomainIdentityMixin):


### PR DESCRIPTION
- Add a method to check if 2 domains are equal (only check for same ID or same name)
- Adds the `DomainIdentityMixin` to models that were missing it.