### PR TITLE
feat: add `include_deprecated` option when fetching images by name

### DIFF
--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -317,6 +317,7 @@ class ImagesClient(ClientEntityBase):
         self,
         name: str,
         architecture: str,
+        *,
         include_deprecated: bool | None = None,
     ) -> BoundImage | None:
         """Get image by name

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -317,6 +317,7 @@ class ImagesClient(ClientEntityBase):
         self,
         name: str,
         architecture: str,
+        include_deprecated: bool | None = None,
     ) -> BoundImage | None:
         """Get image by name
 
@@ -324,9 +325,15 @@ class ImagesClient(ClientEntityBase):
                Used to identify the image.
         :param architecture: str
                Used to identify the image.
+        :param include_deprecated: bool (optional)
+               Include deprecated images. Default: False
         :return: :class:`BoundImage <hcloud.images.client.BoundImage>`
         """
-        return self._get_first_by(name=name, architecture=[architecture])
+        return self._get_first_by(
+            name=name,
+            architecture=[architecture],
+            include_deprecated=include_deprecated,
+        )
 
     def update(
         self,


### PR DESCRIPTION
Allow to get a deprecated image by name.