### PR TITLE
docs: cx11 is name, not an id

### DIFF
--- a/examples/create_server.py
+++ b/examples/create_server.py
@@ -15,7 +15,7 @@ client = Client(token=token)
 
 response = client.servers.create(
     name="my-server",
-    server_type=ServerType("cx11"),
+    server_type=ServerType(name="cx11"),
     image=Image(name="ubuntu-20.04"),
 )
 server = response.server


### PR DESCRIPTION
It doesn't make a real impact, as the `id_or_name` method is called on the object later, but to be technically correct, it would be better to pass the server name as `name` instead of `id`.