### PR TITLE
feat!: make `Client.poll_interval` a private property

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -57,7 +57,7 @@ class Client:
         self._application_version = application_version
         self._requests_session = requests.Session()
         self._requests_timeout = timeout
-        self.poll_interval = poll_interval
+        self._poll_interval = poll_interval
 
         self.datacenters = DatacentersClient(self)
         """DatacentersClient Instance

--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -17,7 +17,7 @@ class BoundAction(BoundModelBase, Action):
     model = Action
 
     def wait_until_finished(self, max_retries: int = 100) -> None:
-        """Wait until the specific action has status="finished" (set Client.poll_interval to specify a delay between checks)
+        """Wait until the specific action has status="finished".
 
         :param max_retries: int
                Specify how many retries will be performed before an ActionTimeoutException will be raised
@@ -28,7 +28,7 @@ class BoundAction(BoundModelBase, Action):
             if max_retries > 0:
                 self.reload()
                 # pylint: disable=protected-access
-                time.sleep(self._client._client.poll_interval)
+                time.sleep(self._client._client._poll_interval)
                 max_retries = max_retries - 1
             else:
                 raise ActionTimeoutException(action=self)

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -19,7 +19,7 @@ class TestBoundAction:
     def bound_running_action(self, mocked_requests):
         action_client = ActionsClient(client=mocked_requests)
         # Speed up tests that run `wait_until_finished`
-        action_client._client.poll_interval = 0.1
+        action_client._client._poll_interval = 0.1
 
         return BoundAction(
             client=action_client,


### PR DESCRIPTION
Prevent the user to read or edit the poll_interval after the client has been constructed.