### PR TITLE
feat!: return empty dict on empty responses in `Client.request`

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -210,9 +210,9 @@ class Client:
             **kwargs,
         )
 
-        content = response.content
+        content = {}
         try:
-            if len(content) > 0:
+            if len(response.content) > 0:
                 content = response.json()
         except (TypeError, ValueError):
             self._raise_exception_from_response(response)
@@ -229,5 +229,4 @@ class Client:
             else:
                 self._raise_exception_from_response(response)
 
-        # TODO: return an empty dict instead of an empty string when content == "".
-        return content  # type: ignore[return-value]
+        return content

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -74,10 +74,6 @@ class TestHetznerClient:
             "Authorization": "Bearer project_token",
         }
 
-    def test_request_library_mocked(self, client):
-        response = client.request("POST", "url", params={"1": 2})
-        assert response.__class__.__name__ == "MagicMock"
-
     def test_request_ok(self, client, response):
         client._requests_session.request.return_value = response
         response = client.request(
@@ -142,7 +138,7 @@ class TestHetznerClient:
         response = client.request(
             "POST", "http://url.com", params={"argument": "value"}, timeout=2
         )
-        assert response == ""
+        assert response == {}
 
     def test_request_500_empty_content(self, client, fail_response):
         fail_response.status_code = 500


### PR DESCRIPTION
This simplifies the API of the request method, and fixes the return values to always be a dict.  