### PR TITLE
feat: add `trace_id` to API exceptions

### DIFF
--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -10,8 +10,22 @@ class HCloudException(Exception):
 class APIException(HCloudException):
     """There was an error while performing an API Request"""
 
-    def __init__(self, code: int | str, message: str | None, details: Any):
-        super().__init__(code if message is None and isinstance(code, str) else message)
+    def __init__(
+        self,
+        code: int | str,
+        message: str,
+        details: Any,
+        *,
+        trace_id: str | None = None,
+    ):
+        extras = [str(code)]
+        if trace_id is not None:
+            extras.append(trace_id)
+
+        error = f"{message} ({', '.join(extras)})"
+
+        super().__init__(error)
         self.code = code
         self.message = message
         self.details = details
+        self.trace_id = trace_id


### PR DESCRIPTION
- Do not use helper functions to raise exceptions,
- Add the request trace ID to the API exceptions,
- Refactor the code.