### PR TITLE
feat!: return full rebuild response in `Client.servers.rebuild`

### DIFF
--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -1006,9 +1005,9 @@ class ServersClient(ClientEntityBase):
         self,
         server: Server | BoundServer,
         image: Image | BoundImage,
-        *,
-        return_response: bool = False,
-    ) -> RebuildResponse | BoundAction:
+        # pylint: disable=unused-argument
+        **kwargs: Any,
+    ) -> RebuildResponse:
         """Rebuilds a server overwriting its disk with the content of an image, thereby destroying all data on the target server.
 
         :param server: Server to rebuild
@@ -1022,21 +1021,10 @@ class ServersClient(ClientEntityBase):
             json=data,
         )
 
-        rebuild_response = RebuildResponse(
+        return RebuildResponse(
             action=BoundAction(self._client.actions, response["action"]),
             root_password=response.get("root_password"),
         )
-
-        if not return_response:
-            warnings.warn(
-                "Returning only the 'action' is deprecated, please set the "
-                "'return_response' keyword argument to 'True' to return the full "
-                "rebuild response and update your code accordingly.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return rebuild_response.action
-        return rebuild_response
 
     def enable_backup(self, server: Server | BoundServer) -> BoundAction:
         """Enables and configures the automatic daily backup option for the server. Enabling automatic backups will increase the price of the server by 20%.

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -1085,11 +1085,6 @@ class TestServersClient:
         assert response.action.progress == 0
         assert response.root_password is None or isinstance(response.root_password, str)
 
-    def test_rebuild_return_response_deprecation(self, servers_client, generic_action):
-        servers_client._client.request.return_value = generic_action
-        with pytest.deprecated_call():
-            servers_client.rebuild(Server(id=1), Image(name="ubuntu-20.04"))
-
     @pytest.mark.parametrize(
         "server", [Server(id=1), BoundServer(mock.MagicMock(), dict(id=1))]
     )


### PR DESCRIPTION
The single action returned was deprecated and is now removed in favor of the full rebuild response with a root password. 