### PR TITLE
fix: rename `trace_id` variable to `correlation_id` 

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -215,7 +215,7 @@ class Client:
             **kwargs,
         )
 
-        trace_id = response.headers.get("X-Correlation-Id")
+        correlation_id = response.headers.get("X-Correlation-Id")
         payload = {}
         try:
             if len(response.content) > 0:
@@ -225,7 +225,7 @@ class Client:
                 code=response.status_code,
                 message=response.reason,
                 details={"content": response.content},
-                trace_id=trace_id,
+                correlation_id=correlation_id,
             ) from exc
 
         if not response.ok:
@@ -234,7 +234,7 @@ class Client:
                     code=response.status_code,
                     message=response.reason,
                     details={"content": response.content},
-                    trace_id=trace_id,
+                    correlation_id=correlation_id,
                 )
 
             error: dict = payload["error"]
@@ -248,7 +248,7 @@ class Client:
                 code=error["code"],
                 message=error["message"],
                 details=error["details"],
-                trace_id=trace_id,
+                correlation_id=correlation_id,
             )
 
         return payload

--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -16,11 +16,11 @@ class APIException(HCloudException):
         message: str,
         details: Any,
         *,
-        trace_id: str | None = None,
+        correlation_id: str | None = None,
     ):
         extras = [str(code)]
-        if trace_id is not None:
-            extras.append(trace_id)
+        if correlation_id is not None:
+            extras.append(correlation_id)
 
         error = f"{message} ({', '.join(extras)})"
 
@@ -28,4 +28,4 @@ class APIException(HCloudException):
         self.code = code
         self.message = message
         self.details = details
-        self.trace_id = trace_id
+        self.correlation_id = correlation_id

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -102,7 +102,7 @@ class TestHetznerClient:
         assert error.message == "invalid input in field 'broken_field': is too long"
         assert error.details["fields"][0]["name"] == "broken_field"
 
-    def test_request_fails_trace_id(self, client, response):
+    def test_request_fails_correlation_id(self, client, response):
         response.headers["X-Correlation-Id"] = "67ed842dc8bc8673"
         response.status_code = 409
         response._content = json.dumps(
@@ -124,7 +124,7 @@ class TestHetznerClient:
         assert error.code == "conflict"
         assert error.message == "some conflict"
         assert error.details is None
-        assert error.trace_id == "67ed842dc8bc8673"
+        assert error.correlation_id == "67ed842dc8bc8673"
         assert str(error) == "some conflict (conflict, 67ed842dc8bc8673)"
 
     def test_request_500(self, client, fail_response):


### PR DESCRIPTION
I learned that we should not use the trace_id name for a correlation_id.

I scoped this change as a fix, as the correltation_id is only used internally.

