### PR TITLE
fix: `assignee_type` is required when creating a primary ip

### DIFF
--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -211,12 +211,12 @@ class PrimaryIPsClient(ClientEntityBase):
         data: dict[str, Any] = {
             "name": name,
             "type": type,
+            "assignee_type": assignee_type,
             "auto_delete": auto_delete,
         }
         if datacenter is not None:
             data["datacenter"] = datacenter.id_or_name
         if assignee_id is not None:
-            data["assignee_type"] = assignee_type
             data["assignee_id"] = assignee_id
         if labels is not None:
             data["labels"] = labels

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -158,6 +158,7 @@ class TestPrimaryIPsClient:
             json={
                 "name": "my-resource",
                 "type": "ipv6",
+                "assignee_type": "server",
                 "datacenter": "datacenter",
                 "auto_delete": False,
             },


### PR DESCRIPTION
The `assignee_type` is always required when creating a primary IP, also when creating an IP in a datacenter (without `assignee_id`).