### PR TITLE
fix: details are optional in API errors

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -247,7 +247,7 @@ class Client:
             raise APIException(
                 code=error["code"],
                 message=error["message"],
-                details=error["details"],
+                details=error.get("details"),
                 correlation_id=correlation_id,
             )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -110,7 +110,6 @@ class TestHetznerClient:
                 "error": {
                     "code": "conflict",
                     "message": "some conflict",
-                    "details": None,
                 }
             }
         ).encode("utf-8")


### PR DESCRIPTION
The ansible integrations tests for `certificate_info` were silently failing because the `details` was missing from the API error.

https://dev.azure.com/ansible/hetzner.hcloud/_build/results?buildId=116526&view=logs&j=790943b1-2131-5e64-166b-e241853dcaf1&t=4ad41445-2459-50a0-f330-095184dc0a34&l=641