### PR TITLE
feat: add exponential and constant backoff function

### DIFF
--- a/hcloud/__init__.py
+++ b/hcloud/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from ._client import Client as Client  # noqa pylint: disable=C0414
+from ._client import (  # noqa pylint: disable=C0414
+    Client as Client,
+    constant_backoff_function as constant_backoff_function,
+    exponential_backoff_function as exponential_backoff_function,
+)
 from ._exceptions import (  # noqa pylint: disable=C0414
     APIException as APIException,
     HCloudException as HCloudException,


### PR DESCRIPTION
- Implement the same backoff function as in the hcloud-go libary
- Preparation work to change the retry backoff function to use an exponential backoff interval.
- Rename PollIntervalFunction to BackoffFunction, as it is not only used for polling.