### PR TITLE
feat: use exponential backoff when retrying requests

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -83,7 +83,9 @@ class Client:
     _version = __version__
     __user_agent_prefix = "hcloud-python"
 
-    _retry_interval = 0.5
+    _retry_interval = exponential_backoff_function(
+        base=1.0, multiplier=2, cap=60.0, jitter=True
+    )
     _retry_max_retries = 5
 
     def __init__(
@@ -289,7 +291,8 @@ class Client:
                     error["code"] == "rate_limit_exceeded"
                     and retries < self._retry_max_retries
                 ):
-                    time.sleep(retries * self._retry_interval)
+                    # pylint: disable=too-many-function-args
+                    time.sleep(self._retry_interval(retries))
                     retries += 1
                     continue
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -185,7 +185,7 @@ class TestHetznerClient:
         assert str(error) == "Internal Server Error (500)"
 
     def test_request_limit(self, client, rate_limit_response):
-        client._retry_interval = 0
+        client._retry_interval = constant_backoff_function(0.0)
         client._requests_session.request.return_value = rate_limit_response
         with pytest.raises(APIException) as exception_info:
             client.request(
@@ -197,7 +197,7 @@ class TestHetznerClient:
         assert error.message == "limit of 10 requests per hour reached"
 
     def test_request_limit_then_success(self, client, rate_limit_response):
-        client._retry_interval = 0
+        client._retry_interval = constant_backoff_function(0.0)
         response = requests.Response()
         response.status_code = 200
         response._content = json.dumps({"result": "data"}).encode("utf-8")


### PR DESCRIPTION
Replace current `retries * retry_interval` backoff with a truncated exponential backoff algorithm.