### PR TITLE
fix: change floating ip labels type to `dict[str, str]`

### DIFF
--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -293,7 +293,7 @@ class FloatingIPsClient(ClientEntityBase):
         self,
         type: str,
         description: str | None = None,
-        labels: str | None = None,
+        labels: dict[str, str] | None = None,
         home_location: Location | BoundLocation | None = None,
         server: Server | BoundServer | None = None,
         name: str | None = None,


### PR DESCRIPTION
The type for the floating ip label was wrong. Its now changed to the type in the comments and works as expected.