### PR TITLE
docs: add links to api changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Official Hetzner Cloud python library.
 
 The library's documentation is available at [hcloud-python.readthedocs.io](https://hcloud-python.readthedocs.io), the public API documentation is available at [docs.hetzner.cloud](https://docs.hetzner.cloud).
 
+> [!IMPORTANT]
+> Make sure to follow our API changelog available at
+> [docs.hetzner.cloud/changelog](https://docs.hetzner.cloud/changelog) (or the RRS feed
+> available at
+> [docs.hetzner.cloud/changelog/feed.rss](https://docs.hetzner.cloud/changelog/feed.rss))
+> to be notified about additions, deprecations and removals.
+
 ## Usage
 
 Install the `hcloud` library:

--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -84,6 +84,11 @@ class Client:
 
     The Hetzner Cloud API reference is available at https://docs.hetzner.cloud.
 
+    Make sure to follow our API changelog available at
+    https://docs.hetzner.cloud/changelog (or the RRS feed available at
+    https://docs.hetzner.cloud/changelog/feed.rss) to be notified about additions,
+    deprecations and removals.
+
     **Retry mechanism**
 
     The :attr:`Client.request` method will retry failed requests that match certain criteria. The


### PR DESCRIPTION
Users must subscribe to our changelog, or they might not be notified about additions, deprecations and removals.