### PR TITLE
feat: improve exception messages

### DIFF
--- a/hcloud/_exceptions.py
+++ b/hcloud/_exceptions.py
@@ -4,11 +4,15 @@ from typing import Any
 
 
 class HCloudException(Exception):
-    """There was an error while using the hcloud library"""
+    """There was an error while using the hcloud library.
+
+    All exceptions in the hcloud library inherit from this exception. It may be used as
+    catch-all exception.
+    """
 
 
 class APIException(HCloudException):
-    """There was an error while performing an API Request"""
+    """There was an error while performing an API Request."""
 
     def __init__(
         self,

--- a/hcloud/actions/domain.py
+++ b/hcloud/actions/domain.py
@@ -71,8 +71,21 @@ class ActionException(HCloudException):
     def __init__(self, action: Action | BoundAction):
         assert self.__doc__ is not None
         message = self.__doc__
-        if action.error is not None and "message" in action.error:
+
+        extras = []
+        if (
+            action.error is not None
+            and "code" in action.error
+            and "message" in action.error
+        ):
             message += f": {action.error['message']}"
+
+            extras.append(action.error["code"])
+        else:
+            extras.append(action.command)
+
+        extras.append(str(action.id))
+        message += f" ({', '.join(extras)})"
 
         super().__init__(message)
         self.message = message

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from hcloud import (
+    APIException,
+    HCloudException,
+)
+from hcloud.actions import Action, ActionFailedException, ActionTimeoutException
+
+running_action = Action(
+    id=12345,
+    command="action_command",
+    status=Action.STATUS_RUNNING,
+)
+
+failed_action = Action(
+    id=12345,
+    command="action_command",
+    status=Action.STATUS_ERROR,
+    error={"code": "action_failed", "message": "Action failed"},
+)
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected"),
+    [
+        (
+            # Should never be raised by itself
+            HCloudException(),
+            "",
+        ),
+        (
+            # Should never be raised by itself
+            HCloudException("A test error"),
+            "A test error",
+        ),
+        (
+            APIException(code="conflict", message="API error message", details=None),
+            "API error message (conflict)",
+        ),
+        (
+            APIException(
+                code="conflict",
+                message="API error message",
+                details=None,
+                correlation_id="fddea8fabd02fb21",
+            ),
+            "API error message (conflict, fddea8fabd02fb21)",
+        ),
+        (
+            ActionFailedException(failed_action),
+            "The pending action failed: Action failed (action_failed, 12345)",
+        ),
+        (
+            ActionTimeoutException(running_action),
+            "The pending action timed out (action_command, 12345)",
+        ),
+    ],
+)
+def test_exceptions(exception, expected):
+    assert str(exception) == expected


### PR DESCRIPTION
Follow the action error message pattern that we used in hcloud-go.