### PR TITLE
fix: missing slots and api_properties for FirewallResourceLabelSelector

### DIFF
--- a/hcloud/firewalls/domain.py
+++ b/hcloud/firewalls/domain.py
@@ -198,6 +198,9 @@ class FirewallResourceLabelSelector(BaseDomain):
     :param selector: str Target label selector
     """
 
+    __api_properties__ = ("selector",)
+    __slots__ = __api_properties__
+
     def __init__(self, selector: str | None = None):
         self.selector = selector
 


### PR DESCRIPTION
Fixes #491

