### PR TITLE
fix: listing page result always provide meta

### DIFF
--- a/hcloud/actions/client.py
+++ b/hcloud/actions/client.py
@@ -47,7 +47,7 @@ class BoundAction(BoundModelBase, Action):
 
 class ActionsPageResult(NamedTuple):
     actions: list[BoundAction]
-    meta: Meta | None
+    meta: Meta
 
 
 class ResourceActionsClient(ClientEntityBase):

--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -100,7 +100,7 @@ class BoundCertificate(BoundModelBase, Certificate):
 
 class CertificatesPageResult(NamedTuple):
     certificates: list[BoundCertificate]
-    meta: Meta | None
+    meta: Meta
 
 
 class CertificatesClient(ClientEntityBase):

--- a/hcloud/core/domain.py
+++ b/hcloud/core/domain.py
@@ -99,13 +99,12 @@ class Meta(BaseDomain):
         self.pagination = pagination
 
     @classmethod
-    def parse_meta(cls, response: dict) -> Meta | None:
+    def parse_meta(cls, response: dict) -> Meta:
         """
         If present, extract the meta details from the response and return a meta object.
         """
-        meta = None
+        meta = cls()
         if response and "meta" in response:
-            meta = cls()
             try:
                 meta.pagination = Pagination(**response["meta"]["pagination"])
             except KeyError:

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -52,7 +52,7 @@ class BoundDatacenter(BoundModelBase, Datacenter):
 
 class DatacentersPageResult(NamedTuple):
     datacenters: list[BoundDatacenter]
-    meta: Meta | None
+    meta: Meta
 
 
 class DatacentersClient(ClientEntityBase):

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -180,7 +180,7 @@ class BoundFirewall(BoundModelBase, Firewall):
 
 class FirewallsPageResult(NamedTuple):
     firewalls: list[BoundFirewall]
-    meta: Meta | None
+    meta: Meta
 
 
 class FirewallsClient(ClientEntityBase):

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -136,7 +136,7 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
 
 class FloatingIPsPageResult(NamedTuple):
     floating_ips: list[BoundFloatingIP]
-    meta: Meta | None
+    meta: Meta
 
 
 class FloatingIPsClient(ClientEntityBase):

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -109,7 +109,7 @@ class BoundImage(BoundModelBase, Image):
 
 class ImagesPageResult(NamedTuple):
     images: list[BoundImage]
-    meta: Meta | None
+    meta: Meta
 
 
 class ImagesClient(ClientEntityBase):

--- a/hcloud/isos/client.py
+++ b/hcloud/isos/client.py
@@ -17,7 +17,7 @@ class BoundIso(BoundModelBase, Iso):
 
 class IsosPageResult(NamedTuple):
     isos: list[BoundIso]
-    meta: Meta | None
+    meta: Meta
 
 
 class IsosClient(ClientEntityBase):

--- a/hcloud/load_balancer_types/client.py
+++ b/hcloud/load_balancer_types/client.py
@@ -17,7 +17,7 @@ class BoundLoadBalancerType(BoundModelBase, LoadBalancerType):
 
 class LoadBalancerTypesPageResult(NamedTuple):
     load_balancer_types: list[BoundLoadBalancerType]
-    meta: Meta | None
+    meta: Meta
 
 
 class LoadBalancerTypesClient(ClientEntityBase):

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -366,7 +366,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
 
 class LoadBalancersPageResult(NamedTuple):
     load_balancers: list[BoundLoadBalancer]
-    meta: Meta | None
+    meta: Meta
 
 
 class LoadBalancersClient(ClientEntityBase):

--- a/hcloud/locations/client.py
+++ b/hcloud/locations/client.py
@@ -17,7 +17,7 @@ class BoundLocation(BoundModelBase, Location):
 
 class LocationsPageResult(NamedTuple):
     locations: list[BoundLocation]
-    meta: Meta | None
+    meta: Meta
 
 
 class LocationsClient(ClientEntityBase):

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -163,7 +163,7 @@ class BoundNetwork(BoundModelBase, Network):
 
 class NetworksPageResult(NamedTuple):
     networks: list[BoundNetwork]
-    meta: Meta | None
+    meta: Meta
 
 
 class NetworksClient(ClientEntityBase):

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -40,7 +40,7 @@ class BoundPlacementGroup(BoundModelBase, PlacementGroup):
 
 class PlacementGroupsPageResult(NamedTuple):
     placement_groups: list[BoundPlacementGroup]
-    meta: Meta | None
+    meta: Meta
 
 
 class PlacementGroupsClient(ClientEntityBase):

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -94,7 +94,7 @@ class BoundPrimaryIP(BoundModelBase, PrimaryIP):
 
 class PrimaryIPsPageResult(NamedTuple):
     primary_ips: list[BoundPrimaryIP]
-    meta: Meta | None
+    meta: Meta
 
 
 class PrimaryIPsClient(ClientEntityBase):

--- a/hcloud/server_types/client.py
+++ b/hcloud/server_types/client.py
@@ -17,7 +17,7 @@ class BoundServerType(BoundModelBase, ServerType):
 
 class ServerTypesPageResult(NamedTuple):
     server_types: list[BoundServerType]
-    meta: Meta | None
+    meta: Meta
 
 
 class ServerTypesClient(ClientEntityBase):

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -479,7 +479,7 @@ class BoundServer(BoundModelBase, Server):
 
 class ServersPageResult(NamedTuple):
     servers: list[BoundServer]
-    meta: Meta | None
+    meta: Meta
 
 
 class ServersClient(ClientEntityBase):

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -38,7 +38,7 @@ class BoundSSHKey(BoundModelBase, SSHKey):
 
 class SSHKeysPageResult(NamedTuple):
     ssh_keys: list[BoundSSHKey]
-    meta: Meta | None
+    meta: Meta
 
 
 class SSHKeysClient(ClientEntityBase):

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -132,7 +132,7 @@ class BoundVolume(BoundModelBase, Volume):
 
 class VolumesPageResult(NamedTuple):
     volumes: list[BoundVolume]
-    meta: Meta | None
+    meta: Meta
 
 
 class VolumesClient(ClientEntityBase):

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -89,7 +89,7 @@ class TestResourceActionsClient:
             url="/resource/actions", method="GET", params=params
         )
 
-        assert result.meta is None
+        assert result.meta is not None
 
         actions = result.actions
         assert len(actions) == 2
@@ -157,7 +157,7 @@ class TestActionsClient:
             url="/actions", method="GET", params=params
         )
 
-        assert result.meta is None
+        assert result.meta is not None
 
         actions = result.actions
         assert len(actions) == 2

--- a/tests/unit/certificates/test_client.py
+++ b/tests/unit/certificates/test_client.py
@@ -29,7 +29,7 @@ class TestBoundCertificate:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -315,7 +315,7 @@ class TestCertificatesClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/core/test_domain.py
+++ b/tests/unit/core/test_domain.py
@@ -10,7 +10,7 @@ class TestMeta:
     @pytest.mark.parametrize("json_content", [None, "", {}])
     def test_parse_meta_empty_json(self, json_content):
         result = Meta.parse_meta(json_content)
-        assert result is None
+        assert result is not None
 
     def test_parse_meta_json_no_paginaton(self):
         json_content = {"meta": {}}

--- a/tests/unit/datacenters/test_client.py
+++ b/tests/unit/datacenters/test_client.py
@@ -82,7 +82,7 @@ class TestDatacentersClient:
         )
 
         datacenters = result.datacenters
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(datacenters) == 2
 

--- a/tests/unit/firewalls/test_client.py
+++ b/tests/unit/firewalls/test_client.py
@@ -84,7 +84,7 @@ class TestBoundFirewall:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -231,7 +231,7 @@ class TestFirewallsClient:
         )
 
         firewalls = result.firewalls
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(firewalls) == 2
 
@@ -305,7 +305,7 @@ class TestFirewallsClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -489,7 +489,7 @@ class TestFirewallsClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/floating_ips/test_client.py
+++ b/tests/unit/floating_ips/test_client.py
@@ -165,7 +165,7 @@ class TestFloatingIPsClient:
         )
 
         bound_floating_ips = result.floating_ips
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(bound_floating_ips) == 2
 
@@ -419,7 +419,7 @@ class TestFloatingIPsClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/images/test_client.py
+++ b/tests/unit/images/test_client.py
@@ -59,7 +59,7 @@ class TestBoundImage:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -162,7 +162,7 @@ class TestImagesClient:
         )
 
         images = result.images
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(images) == 2
 
@@ -254,7 +254,7 @@ class TestImagesClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -337,7 +337,7 @@ class TestImagesClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/isos/test_client.py
+++ b/tests/unit/isos/test_client.py
@@ -63,7 +63,7 @@ class TestIsosClient:
         )
 
         isos = result.isos
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(isos) == 2
 

--- a/tests/unit/load_balancer_types/test_client.py
+++ b/tests/unit/load_balancer_types/test_client.py
@@ -39,7 +39,7 @@ class TestLoadBalancerTypesClient:
         )
 
         load_balancer_types = result.load_balancer_types
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(load_balancer_types) == 2
 

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -46,7 +46,7 @@ class TestBoundLoadBalancer:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -421,7 +421,7 @@ class TestLoadBalancerslient:
         )
 
         bound_load_balancers = result.load_balancers
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(bound_load_balancers) == 2
 
@@ -569,7 +569,7 @@ class TestLoadBalancerslient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/locations/test_client.py
+++ b/tests/unit/locations/test_client.py
@@ -34,7 +34,7 @@ class TestLocationsClient:
         )
 
         locations = result.locations
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(locations) == 2
 

--- a/tests/unit/networks/test_client.py
+++ b/tests/unit/networks/test_client.py
@@ -214,7 +214,7 @@ class TestNetworksClient:
         )
 
         bound_networks = result.networks
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(bound_networks) == 2
 
@@ -613,7 +613,7 @@ class TestNetworksClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/placement_groups/test_client.py
+++ b/tests/unit/placement_groups/test_client.py
@@ -108,7 +108,7 @@ class TestPlacementGroupsClient:
         )
 
         placement_groups = result.placement_groups
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(placement_groups) == len(
             two_placement_groups_response["placement_groups"]

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -321,7 +321,7 @@ class TestPrimaryIPsClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/server_types/test_client.py
+++ b/tests/unit/server_types/test_client.py
@@ -64,7 +64,7 @@ class TestServerTypesClient:
         )
 
         server_types = result.server_types
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(server_types) == 2
 

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -143,7 +143,7 @@ class TestBoundServer:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -558,7 +558,7 @@ class TestServersClient:
         )
 
         bound_servers = result.servers
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(bound_servers) == 2
 
@@ -853,7 +853,7 @@ class TestServersClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)
@@ -1288,7 +1288,7 @@ class TestServersClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)

--- a/tests/unit/volumes/test_client.py
+++ b/tests/unit/volumes/test_client.py
@@ -159,7 +159,7 @@ class TestVolumesClient:
         )
 
         bound_volumes = result.volumes
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(bound_volumes) == 2
 
@@ -412,7 +412,7 @@ class TestVolumesClient:
         )
 
         actions = result.actions
-        assert result.meta is None
+        assert result.meta is not None
 
         assert len(actions) == 1
         assert isinstance(actions[0], BoundAction)


### PR DESCRIPTION
The API specification now describe all meta/pagination fields as required, this PR updates the library to reflect that.

Related #251