### PR TITLE
fix: invalid placement group id casting

### DIFF
--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -1227,7 +1227,7 @@ class ServersClient(ClientEntityBase):
         :param placement_group: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>` or :class:`Network <hcloud.placement_groups.domain.PlacementGroup>`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        data: dict[str, Any] = {"placement_group": str(placement_group.id)}
+        data: dict[str, Any] = {"placement_group": placement_group.id}
         response = self._client.request(
             url=f"/servers/{server.id}/actions/add_to_placement_group",
             method="POST",

--- a/tests/unit/servers/test_client.py
+++ b/tests/unit/servers/test_client.py
@@ -506,7 +506,7 @@ class TestBoundServer:
         hetzner_client.request.assert_called_with(
             url="/servers/14/actions/add_to_placement_group",
             method="POST",
-            json={"placement_group": "897"},
+            json={"placement_group": 897},
         )
 
         assert action.id == 13


### PR DESCRIPTION
The placement group id should be an integer.

See https://docs.hetzner.cloud/#server-actions-add-a-server-to-a-placement-group