### PR TITLE
fix: use valid license identifier (SPDX)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,10 @@ setup(
         "Changelog": "https://github.com/hetznercloud/hcloud-python/blob/main/CHANGELOG.md",
         "Source Code": "https://github.com/hetznercloud/hcloud-python",
     },
-    license="MIT license",
+    license="MIT",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Fixes #513

```
********************************************************************************
Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: MIT License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```

See https://github.com/hetznercloud/hcloud-python/actions/runs/15873016015/job/44753884445#step:5:24