### PR TITLE
docs: fix server metrics example

### DIFF
--- a/examples/get_server_metrics.py
+++ b/examples/get_server_metrics.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os import environ
 
 from hcloud import Client
@@ -24,7 +23,7 @@ if server is None:
     )
     server = response.server
 
-end = datetime.now()
+end = datetime.now(timezone.utc)
 start = end - timedelta(hours=1)
 
 response = server.get_metrics(
@@ -33,4 +32,4 @@ response = server.get_metrics(
     end=end,
 )
 
-print(json.dumps(response.metrics))
+print(response.metrics)


### PR DESCRIPTION
The existing examples/get_server_metrics.py version has 2 problems:
- the iso-formatted dates need a timezone in order to work with the API
- Object of type Metrics is not JSON serializable anymore.

So i added an explicit UTC timezone for the datetime objects, and got rid of the json.dumps() at the end of the script.