### PR TITLE
feat: add category property to server type

### DIFF
--- a/hcloud/server_types/domain.py
+++ b/hcloud/server_types/domain.py
@@ -15,6 +15,8 @@ class ServerType(BaseDomain, DomainIdentityMixin):
            Unique identifier of the server type
     :param description: str
            Description of the server type
+    :param category: str
+           Category of the Server Type.
     :param cores: int
            Number of cpu cores a server of this type will have
     :param memory: int
@@ -42,6 +44,7 @@ class ServerType(BaseDomain, DomainIdentityMixin):
         "id",
         "name",
         "description",
+        "category",
         "cores",
         "memory",
         "disk",
@@ -66,6 +69,7 @@ class ServerType(BaseDomain, DomainIdentityMixin):
         id: int | None = None,
         name: str | None = None,
         description: str | None = None,
+        category: str | None = None,
         cores: int | None = None,
         memory: int | None = None,
         disk: int | None = None,
@@ -80,6 +84,7 @@ class ServerType(BaseDomain, DomainIdentityMixin):
         self.id = id
         self.name = name
         self.description = description
+        self.category = category
         self.cores = cores
         self.memory = memory
         self.disk = disk

--- a/tests/unit/server_types/conftest.py
+++ b/tests/unit/server_types/conftest.py
@@ -10,6 +10,7 @@ def server_type_response():
             "id": 1,
             "name": "cx11",
             "description": "CX11",
+            "category": "Shared vCPU",
             "cores": 1,
             "memory": 1,
             "disk": 25,

--- a/tests/unit/server_types/test_client.py
+++ b/tests/unit/server_types/test_client.py
@@ -22,6 +22,7 @@ class TestBoundServerType:
         assert bound_server_type.id == 1
         assert bound_server_type.name == "cx11"
         assert bound_server_type.description == "CX11"
+        assert bound_server_type.category == "Shared vCPU"
         assert bound_server_type.cores == 1
         assert bound_server_type.memory == 1
         assert bound_server_type.disk == 25


### PR DESCRIPTION
Related to https://docs.hetzner.cloud/changelog#2025-08-25-category-for-server-types