### PR TITLE
refactor: use kwargs when proxying bound model client

### DIFF
--- a/hcloud/certificates/client.py
+++ b/hcloud/certificates/client.py
@@ -53,7 +53,13 @@ class BoundCertificate(BoundModelBase, Certificate):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self,
+            status=status,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_actions(
         self,
@@ -68,7 +74,11 @@ class BoundCertificate(BoundModelBase, Certificate):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(
+            self,
+            status=status,
+            sort=sort,
+        )
 
     def update(
         self,
@@ -83,7 +93,11 @@ class BoundCertificate(BoundModelBase, Certificate):
                User-defined labels (key-value pairs)
         :return: :class:`BoundCertificate <hcloud.certificates.client.BoundCertificate>`
         """
-        return self._client.update(self, name, labels)
+        return self._client.update(
+            self,
+            name=name,
+            labels=labels,
+        )
 
     def delete(self) -> bool:
         """Deletes a certificate.

--- a/hcloud/firewalls/client.py
+++ b/hcloud/firewalls/client.py
@@ -109,7 +109,13 @@ class BoundFirewall(BoundModelBase, Firewall):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self,
+            status=status,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_actions(
         self,
@@ -125,7 +131,11 @@ class BoundFirewall(BoundModelBase, Firewall):
 
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(
+            self,
+            status=status,
+            sort=sort,
+        )
 
     def update(
         self,
@@ -140,7 +150,7 @@ class BoundFirewall(BoundModelBase, Firewall):
                New Name to set
         :return: :class:`BoundFirewall <hcloud.firewalls.client.BoundFirewall>`
         """
-        return self._client.update(self, labels, name)
+        return self._client.update(self, name=name, labels=labels)
 
     def delete(self) -> bool:
         """Deletes a Firewall.
@@ -155,7 +165,7 @@ class BoundFirewall(BoundModelBase, Firewall):
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
 
-        return self._client.set_rules(self, rules)
+        return self._client.set_rules(self, rules=rules)
 
     def apply_to_resources(
         self,
@@ -165,7 +175,7 @@ class BoundFirewall(BoundModelBase, Firewall):
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.apply_to_resources(self, resources)
+        return self._client.apply_to_resources(self, resources=resources)
 
     def remove_from_resources(
         self,
@@ -175,7 +185,7 @@ class BoundFirewall(BoundModelBase, Firewall):
         :param resources: List[:class:`FirewallResource <hcloud.firewalls.domain.FirewallResource>`]
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.remove_from_resources(self, resources)
+        return self._client.remove_from_resources(self, resources=resources)
 
 
 class FirewallsPageResult(NamedTuple):

--- a/hcloud/floating_ips/client.py
+++ b/hcloud/floating_ips/client.py
@@ -55,7 +55,13 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
                 Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self,
+            status=status,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_actions(
         self,
@@ -70,7 +76,7 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(self, status=status, sort=sort)
 
     def update(
         self,
@@ -88,7 +94,9 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
                New Name to set
         :return: :class:`BoundFloatingIP <hcloud.floating_ips.client.BoundFloatingIP>`
         """
-        return self._client.update(self, description, labels, name)
+        return self._client.update(
+            self, description=description, labels=labels, name=name
+        )
 
     def delete(self) -> bool:
         """Deletes a Floating IP. If it is currently assigned to a server it will automatically get unassigned.
@@ -104,7 +112,7 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
                If true, prevents the Floating IP from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_protection(self, delete)
+        return self._client.change_protection(self, delete=delete)
 
     def assign(self, server: Server | BoundServer) -> BoundAction:
         """Assigns a Floating IP to a server.
@@ -113,7 +121,7 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
                Server the Floating IP shall be assigned to
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.assign(self, server)
+        return self._client.assign(self, server=server)
 
     def unassign(self) -> BoundAction:
         """Unassigns a Floating IP, resulting in it being unreachable. You may assign it to a server again at a later time.
@@ -131,7 +139,7 @@ class BoundFloatingIP(BoundModelBase, FloatingIP):
                Hostname to set as a reverse DNS PTR entry, will reset to original default value if `None`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_dns_ptr(self, ip, dns_ptr)
+        return self._client.change_dns_ptr(self, ip=ip, dns_ptr=dns_ptr)
 
 
 class FloatingIPsPageResult(NamedTuple):

--- a/hcloud/images/client.py
+++ b/hcloud/images/client.py
@@ -53,7 +53,11 @@ class BoundImage(BoundModelBase, Image):
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
         return self._client.get_actions_list(
-            self, sort=sort, page=page, per_page=per_page, status=status
+            self,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+            status=status,
         )
 
     def get_actions(
@@ -69,7 +73,11 @@ class BoundImage(BoundModelBase, Image):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status=status, sort=sort)
+        return self._client.get_actions(
+            self,
+            status=status,
+            sort=sort,
+        )
 
     def update(
         self,
@@ -88,7 +96,9 @@ class BoundImage(BoundModelBase, Image):
                User-defined labels (key-value pairs)
         :return: :class:`BoundImage <hcloud.images.client.BoundImage>`
         """
-        return self._client.update(self, description, type, labels)
+        return self._client.update(
+            self, description=description, type=type, labels=labels
+        )
 
     def delete(self) -> bool:
         """Deletes an Image. Only images of type snapshot and backup can be deleted.
@@ -104,7 +114,7 @@ class BoundImage(BoundModelBase, Image):
                If true, prevents the snapshot from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_protection(self, delete)
+        return self._client.change_protection(self, delete=delete)
 
 
 class ImagesPageResult(NamedTuple):

--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -174,7 +174,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                User-defined labels (key-value pairs)
         :return: :class:`BoundLoadBalancer <hcloud.load_balancers.client.BoundLoadBalancer>`
         """
-        return self._client.update(self, name, labels)
+        return self._client.update(self, name=name, labels=labels)
 
     def delete(self) -> bool:
         """Deletes a Load Balancer.
@@ -224,7 +224,13 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self,
+            status=status,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_actions(
         self,
@@ -239,7 +245,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(self, status=status, sort=sort)
 
     def add_service(self, service: LoadBalancerService) -> BoundAction:
         """Adds a service to a Load Balancer.
@@ -266,7 +272,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                        The LoadBalancerService you want to delete from the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.delete_service(self, service)
+        return self._client.delete_service(self, service=service)
 
     def add_target(self, target: LoadBalancerTarget) -> BoundAction:
         """Adds a target to a Load Balancer.
@@ -275,7 +281,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                        The LoadBalancerTarget you want to add to the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.add_target(self, target)
+        return self._client.add_target(self, target=target)
 
     def remove_target(self, target: LoadBalancerTarget) -> BoundAction:
         """Removes a target from a Load Balancer.
@@ -284,7 +290,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                        The LoadBalancerTarget you want to remove from the Load Balancer
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.remove_target(self, target)
+        return self._client.remove_target(self, target=target)
 
     def change_algorithm(self, algorithm: LoadBalancerAlgorithm) -> BoundAction:
         """Changes the algorithm used by the Load Balancer
@@ -293,7 +299,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                        The LoadBalancerAlgorithm you want to use
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_algorithm(self, algorithm)
+        return self._client.change_algorithm(self, algorithm=algorithm)
 
     def change_dns_ptr(self, ip: str, dns_ptr: str) -> BoundAction:
         """Changes the hostname that will appear when getting the hostname belonging to the public IPs (IPv4 and IPv6) of this Load Balancer.
@@ -304,7 +310,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                Hostname to set as a reverse DNS PTR entry, will reset to original default value if `None`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_dns_ptr(self, ip, dns_ptr)
+        return self._client.change_dns_ptr(self, ip=ip, dns_ptr=dns_ptr)
 
     def change_protection(self, delete: bool) -> BoundAction:
         """Changes the protection configuration of a Load Balancer.
@@ -313,7 +319,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                If True, prevents the Load Balancer from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_protection(self, delete)
+        return self._client.change_protection(self, delete=delete)
 
     def attach_to_network(
         self,
@@ -330,7 +336,12 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                 IP range in CIDR block notation of the subnet to attach to.
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.attach_to_network(self, network, ip, ip_range)
+        return self._client.attach_to_network(
+            self,
+            network=network,
+            ip=ip,
+            ip_range=ip_range,
+        )
 
     def detach_from_network(self, network: Network | BoundNetwork) -> BoundAction:
         """Detaches a Load Balancer from a Network.
@@ -338,7 +349,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.detach_from_network(self, network)
+        return self._client.detach_from_network(self, network=network)
 
     def enable_public_interface(self) -> BoundAction:
         """Enables the public interface of a Load Balancer.
@@ -364,7 +375,7 @@ class BoundLoadBalancer(BoundModelBase, LoadBalancer):
                Load Balancer type the Load Balancer should migrate to
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_type(self, load_balancer_type)
+        return self._client.change_type(self, load_balancer_type=load_balancer_type)
 
 
 class LoadBalancersPageResult(NamedTuple):

--- a/hcloud/networks/client.py
+++ b/hcloud/networks/client.py
@@ -89,7 +89,13 @@ class BoundNetwork(BoundModelBase, Network):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self,
+            status=status,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_actions(
         self,
@@ -104,7 +110,7 @@ class BoundNetwork(BoundModelBase, Network):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(self, status=status, sort=sort)
 
     def add_subnet(self, subnet: NetworkSubnet) -> BoundAction:
         """Adds a subnet entry to a network.

--- a/hcloud/placement_groups/client.py
+++ b/hcloud/placement_groups/client.py
@@ -25,7 +25,7 @@ class BoundPlacementGroup(BoundModelBase, PlacementGroup):
                New Name to set
         :return: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>`
         """
-        return self._client.update(self, labels, name)
+        return self._client.update(self, labels=labels, name=name)
 
     def delete(self) -> bool:
         """Deletes a Placement Group

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -43,7 +43,10 @@ class BoundPrimaryIP(BoundModelBase, PrimaryIP):
         :return: :class:`BoundPrimaryIP <hcloud.primary_ips.client.BoundPrimaryIP>`
         """
         return self._client.update(
-            self, auto_delete=auto_delete, labels=labels, name=name
+            self,
+            auto_delete=auto_delete,
+            labels=labels,
+            name=name,
         )
 
     def delete(self) -> bool:
@@ -60,7 +63,7 @@ class BoundPrimaryIP(BoundModelBase, PrimaryIP):
                If true, prevents the Primary IP from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_protection(self, delete)
+        return self._client.change_protection(self, delete=delete)
 
     def assign(self, assignee_id: int, assignee_type: str) -> BoundAction:
         """Assigns a Primary IP to a assignee.
@@ -71,7 +74,9 @@ class BoundPrimaryIP(BoundModelBase, PrimaryIP):
                Assignee type (e.g server) the Primary IP shall be assigned to
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.assign(self, assignee_id, assignee_type)
+        return self._client.assign(
+            self, assignee_id=assignee_id, assignee_type=assignee_type
+        )
 
     def unassign(self) -> BoundAction:
         """Unassigns a Primary IP, resulting in it being unreachable. You may assign it to a server again at a later time.
@@ -89,7 +94,7 @@ class BoundPrimaryIP(BoundModelBase, PrimaryIP):
                Hostname to set as a reverse DNS PTR entry, will reset to original default value if `None`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_dns_ptr(self, ip, dns_ptr)
+        return self._client.change_dns_ptr(self, ip=ip, dns_ptr=dns_ptr)
 
 
 class PrimaryIPsPageResult(NamedTuple):

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -183,7 +183,13 @@ class BoundServer(BoundModelBase, Server):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self,
+            status=status,
+            sort=sort,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_actions(
         self,
@@ -198,7 +204,7 @@ class BoundServer(BoundModelBase, Server):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(self, status=status, sort=sort)
 
     def update(
         self,
@@ -213,7 +219,7 @@ class BoundServer(BoundModelBase, Server):
                User-defined labels (key-value pairs)
         :return: :class:`BoundServer <hcloud.servers.client.BoundServer>`
         """
-        return self._client.update(self, name, labels)
+        return self._client.update(self, name=name, labels=labels)
 
     def get_metrics(
         self,
@@ -327,7 +333,9 @@ class BoundServer(BoundModelBase, Server):
                User-defined labels (key-value pairs)
         :return:  :class:`CreateImageResponse <hcloud.images.domain.CreateImageResponse>`
         """
-        return self._client.create_image(self, description, type, labels)
+        return self._client.create_image(
+            self, description=description, type=type, labels=labels
+        )
 
     def rebuild(
         self,
@@ -339,7 +347,7 @@ class BoundServer(BoundModelBase, Server):
 
         :param image: Image to use for the rebuilt server
         """
-        return self._client.rebuild(self, image)
+        return self._client.rebuild(self, image=image)
 
     def change_type(
         self,
@@ -354,7 +362,9 @@ class BoundServer(BoundModelBase, Server):
                If false, do not upgrade the disk. This allows downgrading the server type later.
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_type(self, server_type, upgrade_disk)
+        return self._client.change_type(
+            self, server_type=server_type, upgrade_disk=upgrade_disk
+        )
 
     def enable_backup(self) -> BoundAction:
         """Enables and configures the automatic daily backup option for the server. Enabling automatic backups will increase the price of the server by 20%.
@@ -376,7 +386,7 @@ class BoundServer(BoundModelBase, Server):
         :param iso: :class:`BoundIso <hcloud.isos.client.BoundIso>` or :class:`Server <hcloud.isos.domain.Iso>`
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.attach_iso(self, iso)
+        return self._client.attach_iso(self, iso=iso)
 
     def detach_iso(self) -> BoundAction:
         """Detaches an ISO from a server.
@@ -394,7 +404,7 @@ class BoundServer(BoundModelBase, Server):
                   Hostname to set as a reverse DNS PTR entry, will reset to original default value if `None`
         :return:  :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_dns_ptr(self, ip, dns_ptr)
+        return self._client.change_dns_ptr(self, ip=ip, dns_ptr=dns_ptr)
 
     def change_protection(
         self,
@@ -410,7 +420,7 @@ class BoundServer(BoundModelBase, Server):
                      If true, prevents the server from being rebuilt (currently delete and rebuild attribute needs to have the same value)
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_protection(self, delete, rebuild)
+        return self._client.change_protection(self, delete=delete, rebuild=rebuild)
 
     def request_console(self) -> RequestConsoleResponse:
         """Requests credentials for remote access via vnc over websocket to keyboard, monitor, and mouse for a server.
@@ -437,7 +447,13 @@ class BoundServer(BoundModelBase, Server):
                 IP range in CIDR block notation of the subnet to attach to.
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.attach_to_network(self, network, ip, alias_ips, ip_range)
+        return self._client.attach_to_network(
+            self,
+            network=network,
+            ip=ip,
+            alias_ips=alias_ips,
+            ip_range=ip_range,
+        )
 
     def detach_from_network(self, network: Network | BoundNetwork) -> BoundAction:
         """Detaches a server from a network.
@@ -445,7 +461,7 @@ class BoundServer(BoundModelBase, Server):
         :param network: :class:`BoundNetwork <hcloud.networks.client.BoundNetwork>` or :class:`Network <hcloud.networks.domain.Network>`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.detach_from_network(self, network)
+        return self._client.detach_from_network(self, network=network)
 
     def change_alias_ips(
         self,
@@ -459,7 +475,7 @@ class BoundServer(BoundModelBase, Server):
                 New alias IPs to set for this server.
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_alias_ips(self, network, alias_ips)
+        return self._client.change_alias_ips(self, network=network, alias_ips=alias_ips)
 
     def add_to_placement_group(
         self,
@@ -470,7 +486,9 @@ class BoundServer(BoundModelBase, Server):
         :param placement_group: :class:`BoundPlacementGroup <hcloud.placement_groups.client.BoundPlacementGroup>` or :class:`Network <hcloud.placement_groups.domain.PlacementGroup>`
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.add_to_placement_group(self, placement_group)
+        return self._client.add_to_placement_group(
+            self, placement_group=placement_group
+        )
 
     def remove_from_placement_group(self) -> BoundAction:
         """Removes a server from a placement group.

--- a/hcloud/ssh_keys/client.py
+++ b/hcloud/ssh_keys/client.py
@@ -24,7 +24,7 @@ class BoundSSHKey(BoundModelBase, SSHKey):
                User-defined labels (key-value pairs)
         :return: :class:`BoundSSHKey <hcloud.ssh_keys.client.BoundSSHKey>`
         """
-        return self._client.update(self, name, labels)
+        return self._client.update(self, name=name, labels=labels)
 
     def delete(self) -> bool:
         """Deletes an SSH key. It cannot be used anymore.

--- a/hcloud/volumes/client.py
+++ b/hcloud/volumes/client.py
@@ -52,7 +52,9 @@ class BoundVolume(BoundModelBase, Volume):
                Specifies how many results are returned by page
         :return: (List[:class:`BoundAction <hcloud.actions.client.BoundAction>`], :class:`Meta <hcloud.core.domain.Meta>`)
         """
-        return self._client.get_actions_list(self, status, sort, page, per_page)
+        return self._client.get_actions_list(
+            self, status=status, sort=sort, page=page, per_page=per_page
+        )
 
     def get_actions(
         self,
@@ -67,7 +69,7 @@ class BoundVolume(BoundModelBase, Volume):
                Specify how the results are sorted. Choices: `id` `id:asc` `id:desc` `command` `command:asc` `command:desc` `status` `status:asc` `status:desc` `progress` `progress:asc` `progress:desc` `started` `started:asc` `started:desc` `finished` `finished:asc` `finished:desc`
         :return: List[:class:`BoundAction <hcloud.actions.client.BoundAction>`]
         """
-        return self._client.get_actions(self, status, sort)
+        return self._client.get_actions(self, status=status, sort=sort)
 
     def update(
         self,
@@ -82,7 +84,7 @@ class BoundVolume(BoundModelBase, Volume):
                User-defined labels (key-value pairs)
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.update(self, name, labels)
+        return self._client.update(self, name=name, labels=labels)
 
     def delete(self) -> bool:
         """Deletes a volume. All volume data is irreversibly destroyed. The volume must not be attached to a server and it must not have delete protection enabled.
@@ -102,7 +104,7 @@ class BoundVolume(BoundModelBase, Volume):
         :param automount: boolean
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.attach(self, server, automount)
+        return self._client.attach(self, server=server, automount=automount)
 
     def detach(self) -> BoundAction:
         """Detaches a volume from the server it’s attached to. You may attach it to a server again at a later time.
@@ -118,7 +120,7 @@ class BoundVolume(BoundModelBase, Volume):
                New volume size in GB (must be greater than current size)
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.resize(self, size)
+        return self._client.resize(self, size=size)
 
     def change_protection(self, delete: bool | None = None) -> BoundAction:
         """Changes the protection configuration of a volume.
@@ -127,7 +129,7 @@ class BoundVolume(BoundModelBase, Volume):
                If True, prevents the volume from being deleted
         :return: :class:`BoundAction <hcloud.actions.client.BoundAction>`
         """
-        return self._client.change_protection(self, delete)
+        return self._client.change_protection(self, delete=delete)
 
 
 class VolumesPageResult(NamedTuple):


### PR DESCRIPTION
Related to #546 