### PR TITLE
ci: ignore spec reference links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -31,6 +31,8 @@ jobs:
             --include-fragments
             --exclude 'api.hetzner.cloud'
             --exclude 'api.hetzner.com'
+            --exclude 'https://docs.hetzner.cloud/reference/cloud#'
+            --exclude 'https://docs.hetzner.cloud/reference/hetzner#'
             --exclude 'codecov.io'
             --exclude 'github.com'
             '**/*.md'


### PR DESCRIPTION
The spec reference anchors are no longer generated server side, lychee therefore cannot check them.

Ignore all the reference links until a better solution is found.