### PR TITLE
fix: missing `__api_properties__` on LoadBalancerService

### DIFF
--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -160,6 +160,16 @@ class LoadBalancerService(BaseDomain):
             Configuration for http/https protocols, required when protocol is http/https
     """
 
+    __api_properties__ = (
+        "protocol",
+        "listen_port",
+        "destination_port",
+        "proxyprotocol",
+        "health_check",
+        "http",
+    )
+    __slots__ = __api_properties__
+
     def __init__(
         self,
         protocol: str | None = None,

--- a/tests/unit/core/test_domain.py
+++ b/tests/unit/core/test_domain.py
@@ -191,3 +191,9 @@ class TestBaseDomain:
         d2.child = [ActionDomain(id=2, name="child2")]
 
         assert d1 != d2
+
+
+def test_base_domain_subclasses():
+    for c in BaseDomain.__subclasses__():
+        assert len(c.__api_properties__) > 0
+        assert len(c.__slots__) > 0


### PR DESCRIPTION
Closes #638

Added a test to make sure all classes inheriting from BaseDomain implements the `__api_properties__` property.