### PR TITLE
feat(primary-ip): `assignee_type` behavior changed when creating a primary ip

### DIFF
--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -311,7 +311,7 @@ class PrimaryIPsClient(
         name: str,
         datacenter: Datacenter | BoundDatacenter | None = None,
         location: Location | BoundLocation | None = None,
-        assignee_type: str | None = "server",
+        assignee_type: str | None = None,
         assignee_id: int | None = None,
         auto_delete: bool | None = False,
         labels: dict[str, str] | None = None,
@@ -328,13 +328,12 @@ class PrimaryIPsClient(
         :param labels: Dict[str, str] (optional) User-defined labels (key-value pairs)
         :return: :class:`CreatePrimaryIPResponse <hcloud.primary_ips.domain.CreatePrimaryIPResponse>`
         """
-
         data: dict[str, Any] = {
             "name": name,
             "type": type,
-            "assignee_type": assignee_type,
             "auto_delete": auto_delete,
         }
+
         if datacenter is not None:
             warnings.warn(
                 "The 'datacenter' argument is deprecated and will be removed after 1 July 2026. "
@@ -348,10 +347,24 @@ class PrimaryIPsClient(
             data["location"] = location.id_or_name
         if assignee_id is not None:
             data["assignee_id"] = assignee_id
+            if assignee_type is None:
+                assignee_type = "server"
+                warnings.warn(
+                    "The 'assignee_type' argument will no longer default to 'server' "
+                    "and will be required together with the 'assignee_id' argument. "
+                    "Please explicitly set the 'assignee_type' argument.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            data["assignee_type"] = assignee_type
         if labels is not None:
             data["labels"] = labels
 
-        response = self._client.request(url=self._base_url, json=data, method="POST")
+        response = self._client.request(
+            method="POST",
+            url=self._base_url,
+            json=data,
+        )
 
         action = None
         if response.get("action") is not None:

--- a/tests/unit/primary_ips/test_client.py
+++ b/tests/unit/primary_ips/test_client.py
@@ -162,7 +162,6 @@ class TestPrimaryIPsClient:
             json={
                 "name": "primary-ip1",
                 "type": "ipv4",
-                "assignee_type": "server",
                 "location": "fsn1",
                 "auto_delete": False,
             },
@@ -194,7 +193,6 @@ class TestPrimaryIPsClient:
             json={
                 "name": "primary-ip1",
                 "type": "ipv4",
-                "assignee_type": "server",
                 "datacenter": "fsn1-dc14",
                 "auto_delete": False,
             },
@@ -235,6 +233,37 @@ class TestPrimaryIPsClient:
 
         assert_bound_primary_ip1(result.primary_ip, resource_client)
         assert_bound_action1(result.action, resource_client._parent.actions)
+
+    def test_create_with_assignee_type_deprecation(
+        self,
+        request_mock: mock.MagicMock,
+        resource_client: PrimaryIPsClient,
+        primary_ip1,
+        action1_running,
+    ):
+        request_mock.return_value = {
+            "primary_ip": primary_ip1,
+            "action": action1_running,
+        }
+
+        with pytest.deprecated_call():
+            resource_client.create(
+                type="ipv4",
+                name="primary-ip1",
+                assignee_id=17,
+            )
+
+        request_mock.assert_called_with(
+            method="POST",
+            url="/primary_ips",
+            json={
+                "name": "primary-ip1",
+                "type": "ipv4",
+                "assignee_id": 17,
+                "assignee_type": "server",
+                "auto_delete": False,
+            },
+        )
 
     @pytest.mark.parametrize(
         "primary_ip",


### PR DESCRIPTION
In the create Primary IP call, the `assignee_type` argument is now only send when the `assignee_id` argument is set. The `assignee_type` argument will stop defaulting to 'server' in the near future, consider explicitly setting this argument when needed.

#### Primary IPs `assignee_type` behavior change

As of 1 August 2026, the behavior of the Primary IP `assignee_type` property will change, and will return `unassigned` when the Primary IP is not assigned (when `assignee_id` is `null`). The goal is to eventually assign Primary IPs to other resource types, not only to `server`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned) for more details.

In addition, the Primary IP request body `assignee_type` property of the operation [`POST /v1/primary_ips`](https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip) is now optional. Primary IPs created without `assignee_type` return `server` until 1 August 2026, after this date, its value will be `unassigned`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional) for more details.