### PR TITLE
feat(load-balancer): support `timeout_idle` http service field

### DIFF
--- a/hcloud/load_balancers/client.py
+++ b/hcloud/load_balancers/client.py
@@ -155,6 +155,7 @@ class BoundLoadBalancer(BoundModelBase[LoadBalancer], LoadBalancer):
                         redirect_http=service["http"]["redirect_http"],
                         cookie_name=service["http"]["cookie_name"],
                         cookie_lifetime=service["http"]["cookie_lifetime"],
+                        timeout_idle=service["http"]["timeout_idle"],
                     )
                     tmp_service.http.certificates = [
                         BoundCertificate(

--- a/hcloud/load_balancers/domain.py
+++ b/hcloud/load_balancers/domain.py
@@ -212,6 +212,8 @@ class LoadBalancerService(BaseDomain):
                 http["redirect_http"] = self.http.redirect_http
             if self.http.sticky_sessions is not None:
                 http["sticky_sessions"] = self.http.sticky_sessions
+            if self.http.timeout_idle is not None:
+                http["timeout_idle"] = self.http.timeout_idle
 
             http["certificates"] = [
                 certificate.id for certificate in self.http.certificates or []
@@ -272,6 +274,8 @@ class LoadBalancerServiceHttp(BaseDomain):
            Redirect traffic from http port 80 to port 443
     :param sticky_sessions: bool
            Use sticky sessions. Only available if protocol is "http" or "https".
+    :param timeout_idle: int
+           Idle timeout in seconds for HTTP connections. Must be between 30 and 300 seconds.
     """
 
     __api_properties__ = (
@@ -280,6 +284,7 @@ class LoadBalancerServiceHttp(BaseDomain):
         "certificates",
         "redirect_http",
         "sticky_sessions",
+        "timeout_idle",
     )
     __slots__ = __api_properties__
 
@@ -290,12 +295,14 @@ class LoadBalancerServiceHttp(BaseDomain):
         certificates: list[BoundCertificate] | None = None,
         redirect_http: bool | None = None,
         sticky_sessions: bool | None = None,
+        timeout_idle: int | None = None,
     ):
         self.cookie_name = cookie_name
         self.cookie_lifetime = cookie_lifetime
         self.certificates = certificates
         self.redirect_http = redirect_http
         self.sticky_sessions = sticky_sessions
+        self.timeout_idle = timeout_idle
 
 
 class LoadBalancerHealthCheck(BaseDomain):

--- a/tests/unit/load_balancers/conftest.py
+++ b/tests/unit/load_balancers/conftest.py
@@ -62,6 +62,7 @@ def response_load_balancer():
                         "certificates": [897],
                         "redirect_http": True,
                         "sticky_sessions": True,
+                        "timeout_idle": 60,
                     },
                     "health_check": {
                         "protocol": "http",
@@ -155,6 +156,7 @@ def response_create_load_balancer():
                         "certificates": [897],
                         "redirect_http": True,
                         "sticky_sessions": True,
+                        "timeout_idle": 60,
                     },
                     "health_check": {
                         "protocol": "http",
@@ -253,6 +255,7 @@ def response_update_load_balancer():
                         "certificates": [897],
                         "redirect_http": True,
                         "sticky_sessions": True,
+                        "timeout_idle": 60,
                     },
                     "health_check": {
                         "protocol": "http",
@@ -344,6 +347,7 @@ def response_simple_load_balancers():
                             "cookie_lifetime": 300,
                             "certificates": [897],
                             "redirect_http": True,
+                            "timeout_idle": 60,
                         },
                         "health_check": {
                             "protocol": "http",
@@ -428,6 +432,7 @@ def response_simple_load_balancers():
                             "cookie_lifetime": 300,
                             "certificates": [897],
                             "redirect_http": True,
+                            "timeout_idle": 60,
                         },
                         "health_check": {
                             "protocol": "http",

--- a/tests/unit/load_balancers/test_client.py
+++ b/tests/unit/load_balancers/test_client.py
@@ -13,6 +13,7 @@ from hcloud.load_balancers import (
     LoadBalancerHealthCheck,
     LoadBalancersClient,
     LoadBalancerService,
+    LoadBalancerServiceHttp,
     LoadBalancerTarget,
     LoadBalancerTargetIP,
     LoadBalancerTargetLabelSelector,
@@ -383,13 +384,38 @@ class TestLoadBalancerslient:
     ):
         request_mock.return_value = response_add_service
 
-        service = LoadBalancerService(listen_port=80, protocol="http")
+        service = LoadBalancerService(
+            listen_port=80,
+            protocol="http",
+            destination_port=8080,
+            proxyprotocol=False,
+            http=LoadBalancerServiceHttp(
+                cookie_name="HCLBSTICKY",
+                cookie_lifetime=300,
+                redirect_http=True,
+                sticky_sessions=True,
+                timeout_idle=60,
+            ),
+        )
         action = resource_client.add_service(load_balancer, service)
 
         request_mock.assert_called_with(
             method="POST",
             url="/load_balancers/1/actions/add_service",
-            json={"protocol": "http", "listen_port": 80},
+            json={
+                "protocol": "http",
+                "listen_port": 80,
+                "destination_port": 8080,
+                "proxyprotocol": False,
+                "http": {
+                    "cookie_name": "HCLBSTICKY",
+                    "cookie_lifetime": 300,
+                    "redirect_http": True,
+                    "sticky_sessions": True,
+                    "timeout_idle": 60,
+                    "certificates": [],
+                },
+            },
         )
 
         assert action.id == 13


### PR DESCRIPTION
`timeout_idle` controls the time a http connection is allowed to idle before the load balancer drops the connection.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-30-load-balancers-http-idle-timeout-can-now-be-configured) for more information.