### PR TITLE
feat: deprecate datacenters

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from http import HTTPStatus
 from random import uniform
 from typing import Any, Protocol
@@ -181,11 +182,10 @@ class Client:
             timeout=timeout,
         )
 
-        self.datacenters = DatacentersClient(self)
-        """DatacentersClient Instance
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self.datacenters = DatacentersClient(self)
 
-        :type: :class:`DatacentersClient <hcloud.datacenters.client.DatacentersClient>`
-        """
         self.locations = LocationsClient(self)
         """LocationsClient Instance
 
@@ -302,6 +302,28 @@ class Client:
         :param timeout: Requests timeout in seconds.
         """
         return self._client.request(method, url, **kwargs)
+
+    @property
+    def datacenters(self) -> DatacentersClient:
+        """DatacentersClient Instance
+
+        .. deprecated:: 2.22.0
+            The datacenters client is deprecated and will be removed after the 2026-10-01.
+            See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
+
+        :type: :class:`DatacentersClient <hcloud.datacenters.client.DatacentersClient>`
+        """
+        warnings.warn(
+            "The datacenters client is deprecated and will be removed after the 2026-10-01. "
+            "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._datacenters
+
+    @datacenters.setter
+    def datacenters(self, value: DatacentersClient) -> None:
+        self._datacenters = value
 
 
 class ClientBase:

--- a/hcloud/core/client.py
+++ b/hcloud/core/client.py
@@ -109,7 +109,10 @@ class BoundModelBase(Generic[Domain]):
         """
         self._client = client
         self.complete = complete
-        self.data_model: Domain = self.model.from_dict(data)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self.data_model: Domain = self.model.from_dict(data)
 
     def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
         """Allow magical access to the properties of the model

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -17,52 +17,50 @@ __all__ = [
     "DatacentersClient",
 ]
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-    class BoundDatacenter(BoundModelBase[Datacenter], Datacenter):
-        """
-        .. deprecated:: 2.22.0
-            The bound datacenter class is deprecated and will be removed after the 2026-10-01.
-            See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
-        """
+class BoundDatacenter(BoundModelBase[Datacenter], Datacenter):
+    """
+    .. deprecated:: 2.22.0
+        The bound datacenter class is deprecated and will be removed after the 2026-10-01.
+        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
+    """
 
-        _client: DatacentersClient
+    _client: DatacentersClient
 
-        model = Datacenter
+    model = Datacenter
 
-        def __init__(self, client: DatacentersClient, data: dict[str, Any]):
-            location = data.get("location")
-            if location is not None:
-                data["location"] = BoundLocation(client._parent.locations, location)
+    def __init__(self, client: DatacentersClient, data: dict[str, Any]):
+        location = data.get("location")
+        if location is not None:
+            data["location"] = BoundLocation(client._parent.locations, location)
 
-            server_types = data.get("server_types")
-            if server_types is not None:
-                available = [
-                    BoundServerType(
-                        client._parent.server_types, {"id": server_type}, complete=False
-                    )
-                    for server_type in server_types["available"]
-                ]
-                supported = [
-                    BoundServerType(
-                        client._parent.server_types, {"id": server_type}, complete=False
-                    )
-                    for server_type in server_types["supported"]
-                ]
-                available_for_migration = [
-                    BoundServerType(
-                        client._parent.server_types, {"id": server_type}, complete=False
-                    )
-                    for server_type in server_types["available_for_migration"]
-                ]
-                data["server_types"] = DatacenterServerTypes(
-                    available=available,
-                    supported=supported,
-                    available_for_migration=available_for_migration,
+        server_types = data.get("server_types")
+        if server_types is not None:
+            available = [
+                BoundServerType(
+                    client._parent.server_types, {"id": server_type}, complete=False
                 )
+                for server_type in server_types["available"]
+            ]
+            supported = [
+                BoundServerType(
+                    client._parent.server_types, {"id": server_type}, complete=False
+                )
+                for server_type in server_types["supported"]
+            ]
+            available_for_migration = [
+                BoundServerType(
+                    client._parent.server_types, {"id": server_type}, complete=False
+                )
+                for server_type in server_types["available_for_migration"]
+            ]
+            data["server_types"] = DatacenterServerTypes(
+                available=available,
+                supported=supported,
+                available_for_migration=available_for_migration,
+            )
 
-            super().__init__(client, data)
+        super().__init__(client, data)
 
 
 class DatacentersPageResult(NamedTuple):

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, NamedTuple
 
 from ..core import BoundModelBase, Meta, ResourceClientBase
@@ -13,52 +14,76 @@ __all__ = [
     "DatacentersClient",
 ]
 
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-class BoundDatacenter(BoundModelBase[Datacenter], Datacenter):
-    _client: DatacentersClient
+    class BoundDatacenter(BoundModelBase[Datacenter], Datacenter):
+        """
+        .. deprecated:: 2.22.0
+            The bound datacenter class is deprecated and will be removed after the 2026-10-01.
+            See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
+        """
 
-    model = Datacenter
+        _client: DatacentersClient
 
-    def __init__(self, client: DatacentersClient, data: dict[str, Any]):
-        location = data.get("location")
-        if location is not None:
-            data["location"] = BoundLocation(client._parent.locations, location)
+        model = Datacenter
 
-        server_types = data.get("server_types")
-        if server_types is not None:
-            available = [
-                BoundServerType(
-                    client._parent.server_types, {"id": server_type}, complete=False
+        def __init__(self, client: DatacentersClient, data: dict[str, Any]):
+            location = data.get("location")
+            if location is not None:
+                data["location"] = BoundLocation(client._parent.locations, location)
+
+            server_types = data.get("server_types")
+            if server_types is not None:
+                available = [
+                    BoundServerType(
+                        client._parent.server_types, {"id": server_type}, complete=False
+                    )
+                    for server_type in server_types["available"]
+                ]
+                supported = [
+                    BoundServerType(
+                        client._parent.server_types, {"id": server_type}, complete=False
+                    )
+                    for server_type in server_types["supported"]
+                ]
+                available_for_migration = [
+                    BoundServerType(
+                        client._parent.server_types, {"id": server_type}, complete=False
+                    )
+                    for server_type in server_types["available_for_migration"]
+                ]
+                data["server_types"] = DatacenterServerTypes(
+                    available=available,
+                    supported=supported,
+                    available_for_migration=available_for_migration,
                 )
-                for server_type in server_types["available"]
-            ]
-            supported = [
-                BoundServerType(
-                    client._parent.server_types, {"id": server_type}, complete=False
-                )
-                for server_type in server_types["supported"]
-            ]
-            available_for_migration = [
-                BoundServerType(
-                    client._parent.server_types, {"id": server_type}, complete=False
-                )
-                for server_type in server_types["available_for_migration"]
-            ]
-            data["server_types"] = DatacenterServerTypes(
-                available=available,
-                supported=supported,
-                available_for_migration=available_for_migration,
-            )
 
-        super().__init__(client, data)
+            super().__init__(client, data)
 
 
 class DatacentersPageResult(NamedTuple):
+    """
+    .. deprecated:: 2.22.0
+        The datacenters page result class is deprecated and will be removed after the 2026-10-01.
+        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
+    """
+
     datacenters: list[BoundDatacenter]
     meta: Meta
 
 
+@warnings.deprecated(
+    "The datacenters client class is deprecated and will be removed after the 2026-10-01. "
+    "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
+)
 class DatacentersClient(ResourceClientBase):
+    """
+    .. deprecated:: 2.22.0
+        The datacenters client class is deprecated and will be removed after the 2026-10-01.
+        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
+    """
+
     _base_url = "/datacenters"
 
     def get_by_id(self, id: int) -> BoundDatacenter:

--- a/hcloud/datacenters/client.py
+++ b/hcloud/datacenters/client.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..core import BoundModelBase, Meta, ResourceClientBase
 from ..locations import BoundLocation
 from ..server_types import BoundServerType
 from .domain import Datacenter, DatacenterServerTypes
+
+if TYPE_CHECKING:
+    from .._client import Client
 
 __all__ = [
     "BoundDatacenter",
@@ -73,10 +76,6 @@ class DatacentersPageResult(NamedTuple):
     meta: Meta
 
 
-@warnings.deprecated(
-    "The datacenters client class is deprecated and will be removed after the 2026-10-01. "
-    "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
-)
 class DatacentersClient(ResourceClientBase):
     """
     .. deprecated:: 2.22.0
@@ -85,6 +84,15 @@ class DatacentersClient(ResourceClientBase):
     """
 
     _base_url = "/datacenters"
+
+    def __init__(self, client: Client):
+        warnings.warn(
+            "The datacenters client class is deprecated and will be removed after the 2026-10-01. "
+            "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(client)
 
     def get_by_id(self, id: int) -> BoundDatacenter:
         """Get a specific datacenter by its ID.

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -15,8 +15,16 @@ __all__ = [
 ]
 
 
+@warnings.deprecated(
+    "The datacenter domain class is deprecated and will be removed after the 2026-10-01. "
+    "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
+)
 class Datacenter(BaseDomain, DomainIdentityMixin):
     """Datacenter Domain
+
+    .. deprecated:: 2.22.0
+        The datacenters domain class is deprecated and will be removed after the 2026-10-01.
+        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 
     :param id: int ID of Datacenter
     :param name: str Name of Datacenter
@@ -68,6 +76,10 @@ class Datacenter(BaseDomain, DomainIdentityMixin):
 
 class DatacenterServerTypes(BaseDomain):
     """DatacenterServerTypes Domain
+
+    .. deprecated:: 2.22.0
+        The datacenters domain class is deprecated and will be removed after the 2026-10-01.
+        See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 
     :param available: List[:class:`BoundServerTypes <hcloud.server_types.client.BoundServerTypes>`]
            All available server types for this datacenter

--- a/hcloud/datacenters/domain.py
+++ b/hcloud/datacenters/domain.py
@@ -15,10 +15,6 @@ __all__ = [
 ]
 
 
-@warnings.deprecated(
-    "The datacenter domain class is deprecated and will be removed after the 2026-10-01. "
-    "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
-)
 class Datacenter(BaseDomain, DomainIdentityMixin):
     """Datacenter Domain
 
@@ -45,6 +41,12 @@ class Datacenter(BaseDomain, DomainIdentityMixin):
         location: Location | None = None,
         server_types: DatacenterServerTypes | None = None,
     ):
+        warnings.warn(
+            "The datacenter domain class is deprecated and will be removed after the 2026-10-01. "
+            "See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.id = id
         self.name = name
         self.description = description

--- a/hcloud/primary_ips/client.py
+++ b/hcloud/primary_ips/client.py
@@ -44,7 +44,9 @@ class BoundPrimaryIP(BoundModelBase[PrimaryIP], PrimaryIP):
 
         raw = data.get("datacenter", {})
         if raw:
-            data["datacenter"] = BoundDatacenter(client._parent.datacenters, raw)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                data["datacenter"] = BoundDatacenter(client._parent.datacenters, raw)
 
         raw = data.get("location", {})
         if raw:

--- a/hcloud/servers/client.py
+++ b/hcloud/servers/client.py
@@ -77,7 +77,9 @@ class BoundServer(BoundModelBase[Server], Server):
     ):
         raw = data.get("datacenter")
         if raw:
-            data["datacenter"] = BoundDatacenter(client._parent.datacenters, raw)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                data["datacenter"] = BoundDatacenter(client._parent.datacenters, raw)
 
         raw = data.get("location")
         if raw:

--- a/tests/unit/actions/test_client.py
+++ b/tests/unit/actions/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import warnings
 from unittest import mock
 
 import pytest
@@ -47,10 +48,15 @@ def test_resources_with_actions(client: Client):
     """
     Ensure that the list of resource clients above is up to date.
     """
-    members = inspect.getmembers(
-        client,
-        predicate=lambda p: isinstance(p, ResourceClientBase) and hasattr(p, "actions"),
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+        members = inspect.getmembers(
+            client,
+            predicate=lambda p: isinstance(p, ResourceClientBase)
+            and hasattr(p, "actions"),
+        )
+
     for name, member in members:
         assert name in resources_with_actions
 

--- a/tests/unit/datacenters/test_client.py
+++ b/tests/unit/datacenters/test_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from unittest import mock  # noqa: F401
 
 import pytest  # noqa: F401
@@ -7,6 +8,8 @@ import pytest  # noqa: F401
 from hcloud import Client
 from hcloud.datacenters import BoundDatacenter, DatacentersClient, DatacenterServerTypes
 from hcloud.locations import BoundLocation
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 class TestBoundDatacenter:
@@ -64,7 +67,9 @@ class TestBoundDatacenter:
 class TestDatacentersClient:
     @pytest.fixture()
     def datacenters_client(self, client: Client):
-        return DatacentersClient(client)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return DatacentersClient(client)
 
     def test_get_by_id(
         self,

--- a/tests/unit/datacenters/test_domain.py
+++ b/tests/unit/datacenters/test_domain.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from hcloud.datacenters import Datacenter, DatacenterServerTypes
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The API endpoints `GET /v1/datacenters` and `GET /v1/datacenters/{id}` are now deprecated and will be removed after 1 Oct. 2026. After this date, requests to these endpoints will return `HTTP 410 Gone`.

See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.