### PR TITLE
feat: retry requests on api bad_gateway error

### DIFF
--- a/hcloud/_client.py
+++ b/hcloud/_client.py
@@ -129,6 +129,7 @@ class Client:
 
         - ``conflict``
         - ``rate_limit_exceeded``
+        - ``bad_gateway``
         - ``timeout``
 
     Changes to the retry policy might occur between releases, and will not be considered
@@ -420,6 +421,7 @@ class ClientBase:
             return exception.code in (
                 "rate_limit_exceeded",
                 "conflict",
+                "bad_gateway",
                 "timeout",
             )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -107,6 +107,10 @@ class TestBaseClient:
                 True,
             ),
             (
+                APIException(code="bad_gateway", message="Error", details=None),
+                True,
+            ),
+            (
                 APIException(code=409, message="Conflict", details=None),
                 False,
             ),


### PR DESCRIPTION
If the API returns an error code `bad_gateway`, retry the failed request.