### PR TITLE
feat: add deprecation info to load balancer type

### DIFF
--- a/hcloud/load_balancer_types/domain.py
+++ b/hcloud/load_balancer_types/domain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..core import BaseDomain, DomainIdentityMixin
+from ..deprecation import DeprecationInfo
 
 __all__ = [
     "LoadBalancerType",
@@ -28,7 +29,7 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
            Max amount of certificates the Load Balancer can serve
     :param prices: List of dict
            Prices in different locations
-
+    :param deprecation: Define if and when the Load Balancer Type is deprecated.
     """
 
     __api_properties__ = (
@@ -40,6 +41,7 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
         "max_targets",
         "max_assigned_certificates",
         "prices",
+        "deprecation",
     )
     __slots__ = __api_properties__
 
@@ -53,6 +55,7 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
         max_targets: int | None = None,
         max_assigned_certificates: int | None = None,
         prices: list[dict[str, Any]] | None = None,
+        deprecation: dict[str, Any] | None = None,
     ):
         self.id = id
         self.name = name
@@ -62,3 +65,4 @@ class LoadBalancerType(BaseDomain, DomainIdentityMixin):
         self.max_targets = max_targets
         self.max_assigned_certificates = max_assigned_certificates
         self.prices = prices
+        self.deprecation = deprecation and DeprecationInfo.from_dict(deprecation)

--- a/tests/unit/load_balancer_types/test_client.py
+++ b/tests/unit/load_balancer_types/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from dateutil.parser import isoparse
 
 from hcloud import Client
 from hcloud.load_balancer_types import LoadBalancerTypesClient
@@ -47,6 +48,10 @@ class TestLoadBalancerTypesClient:
                 "included_traffic": 21990232555520,
             }
         ]
+        assert result.deprecation.announced == isoparse("2023-06-01T00:00:00+00:00")
+        assert result.deprecation.unavailable_after == isoparse(
+            "2023-09-01T00:00:00+00:00"
+        )
 
     @pytest.mark.parametrize(
         "params", [{"name": "lb11", "page": 1, "per_page": 10}, {"name": ""}, {}]


### PR DESCRIPTION
- https://docs.hetzner.cloud/changelog#2026-06-05-deprecation-info-for-load-balancer-types

Add the `deprecation` object property to the `LoadBalancerType` domain.